### PR TITLE
add feature_flag and allocation to assignment log event; construct experiment from a compound

### DIFF
--- a/dot-net-sdk/EppoClient.cs
+++ b/dot-net-sdk/EppoClient.cs
@@ -46,11 +46,11 @@ public class EppoClient
     }
 
 
-
     private EppoValue? GetAssignment(string subjectKey, string flagKey, SubjectAttributes subjectAttributes)
     {
         InputValidator.ValidateNotBlank(subjectKey, "Invalid argument: subjectKey cannot be blank");
         InputValidator.ValidateNotBlank(flagKey, "Invalid argument: flagKey cannot be blank");
+
         var configuration = this._configurationStore.GetExperimentConfiguration(flagKey);
         if (configuration == null)
         {
@@ -92,12 +92,13 @@ public class EppoClient
             _eppoClientConfig.AssignmentLogger
                 .LogAssignment(new AssignmentLogData(
                     flagKey,
+                    rule.allocationKey,
                     assignedVariation.typedValue.StringValue(),
                     subjectKey,
                     subjectAttributes
                 ));
         }
-        catch (Exception e)
+        catch (Exception)
         {
             // Ignore Exception
         }
@@ -105,17 +106,17 @@ public class EppoClient
         return assignedVariation?.typedValue;
     }
 
-    private bool IsInExperimentSample(string subjectKey, string experimentKey, int subjectShards,
+    private bool IsInExperimentSample(string subjectKey, string flagKey, int subjectShards,
         float percentageExposure)
     {
-        var shard = Shard.GetShard($"exposure-{subjectKey}-{experimentKey}", subjectShards);
+        var shard = Shard.GetShard($"exposure-{subjectKey}-{flagKey}", subjectShards);
         return shard <= percentageExposure * subjectShards;
     }
 
-    private Variation GetAssignedVariation(string subjectKey, string experimentKey, int subjectShards,
+    private Variation GetAssignedVariation(string subjectKey, string flagKey, int subjectShards,
         List<Variation> variations)
     {
-        var shard = Shard.GetShard($"assignment-{subjectKey}-{experimentKey}", subjectShards);
+        var shard = Shard.GetShard($"assignment-{subjectKey}-{flagKey}", subjectShards);
         return variations.Find(config => Shard.IsInRange(shard, config.shardRange))!;
     }
 

--- a/dot-net-sdk/dto/AssignmentLogData.cs
+++ b/dot-net-sdk/dto/AssignmentLogData.cs
@@ -3,13 +3,23 @@ namespace eppo_sdk.dto;
 public class AssignmentLogData
 {
     public string experiment;
+    public string feature_flag;
+    public string allocation;
     public string variation;
     public DateTime timestamp;
     public string subject;
     public SubjectAttributes subjectAttributes;
 
-    public AssignmentLogData(string experiment, string variation, string subject, SubjectAttributes subjectAttributes) {
-        this.experiment = experiment;
+    public AssignmentLogData(
+        string feature_flag,
+        string allocation,
+        string variation,
+        string subject,
+        SubjectAttributes subjectAttributes)
+    {
+        this.experiment = feature_flag + "-" + allocation;
+        this.feature_flag = feature_flag;
+        this.allocation = allocation;
         this.variation = variation;
         this.timestamp = new DateTime();
         this.subject = subject;

--- a/dot-net-sdk/eppo-sdk.csproj
+++ b/dot-net-sdk/eppo-sdk.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/Eppo-exp/dot-net-server-sdk</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Eppo-exp/dot-net-server-sdk</RepositoryUrl>
     <PackageId>Eppo.Sdk</PackageId>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Company>Eppo Data</Company>
   </PropertyGroup>
 

--- a/eppo-sdk-test/helpers/AssignmentLogDataTest.cs
+++ b/eppo-sdk-test/helpers/AssignmentLogDataTest.cs
@@ -1,0 +1,18 @@
+using eppo_sdk.dto;
+
+namespace eppo_sdk_test.helpers;
+
+public class AssignmentLogDataTest
+{
+    [Test]
+    public void ShouldReturnAssignmentLogData()
+    {
+        var assignmentLogData = new AssignmentLogData(
+            "feature-flag",
+            "allocation",
+            "variation",
+            "subject",
+            new SubjectAttributes());
+        Assert.That(assignmentLogData.experiment, Is.EqualTo("feature-flag-allocation"));
+    }
+}


### PR DESCRIPTION
## motivation

support correct analysis when subjects are part of an allocation group

## description

log the allocation key as part of the assignment callback and construct the `experiment` without user input by from a concatenation of `feature_flag` and `allocation`.