### PR TITLE
Make feature_flag event attribute camelCase

### DIFF
--- a/dot-net-sdk/dto/AssignmentLogData.cs
+++ b/dot-net-sdk/dto/AssignmentLogData.cs
@@ -3,7 +3,7 @@ namespace eppo_sdk.dto;
 public class AssignmentLogData
 {
     public string experiment;
-    public string feature_flag;
+    public string featureFlag;
     public string allocation;
     public string variation;
     public DateTime timestamp;
@@ -11,14 +11,14 @@ public class AssignmentLogData
     public SubjectAttributes subjectAttributes;
 
     public AssignmentLogData(
-        string feature_flag,
+        string featureFlag,
         string allocation,
         string variation,
         string subject,
         SubjectAttributes subjectAttributes)
     {
-        this.experiment = feature_flag + "-" + allocation;
-        this.feature_flag = feature_flag;
+        this.experiment = featureFlag + "-" + allocation;
+        this.featureFlag = featureFlag;
         this.allocation = allocation;
         this.variation = variation;
         this.timestamp = new DateTime();


### PR DESCRIPTION
I missed this in the earlier [PR](https://github.com/Eppo-exp/dot-net-server-sdk/pull/4). 

The event attribute for feature flag should be camelCase to be consistent with how the object is logged by the other SDKs (e.g. Java: https://github.com/Eppo-exp/java-server-sdk/pull/20/files#diff-b32205c6af8b00131a3ced04490001a51a2b2aecde72898e47724493d4319a41R26) and with the other event attribute `subjectAttributes`

Do I need to increment the version number again for the release process?