### PR TITLE
Add JSON (more specifically JObject) as ValueType (FF-999)

### DIFF
--- a/dot-net-sdk/EppoClient.cs
+++ b/dot-net-sdk/EppoClient.cs
@@ -6,6 +6,7 @@ using eppo_sdk.http;
 using eppo_sdk.store;
 using eppo_sdk.tasks;
 using eppo_sdk.validators;
+using Newtonsoft.Json.Linq;
 using NLog;
 
 namespace eppo_sdk;
@@ -43,6 +44,12 @@ public class EppoClient
     public int? GetIntegerAssignment(string subjectKey, string flagKey, SubjectAttributes? subjectAttributes = null)
     {
         return GetAssignment(subjectKey, flagKey, subjectAttributes ?? new SubjectAttributes())?.IntegerValue();
+    }
+
+
+    public JObject? GetJsonAssignment(string subjectKey, string flagKey, SubjectAttributes? subjectAttributes = null)
+    {
+        return GetAssignment(subjectKey, flagKey, subjectAttributes ?? new SubjectAttributes())?.JsonValue();
     }
 
 

--- a/dot-net-sdk/dto/EppoValue.cs
+++ b/dot-net-sdk/dto/EppoValue.cs
@@ -1,6 +1,8 @@
 using System.Dynamic;
 using System.Globalization;
 using System.Text.Json.Nodes;
+using Common.Logging;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -76,7 +78,8 @@ public class EppoValue
             }
             catch (JsonReaderException)
             {
-
+                var log = LogManager.GetLogger<EppoValue>();
+                log.Error($"Unable to deserialize <{_json}> into a JSON obect.");
             }
         }
         return _json;

--- a/dot-net-sdk/dto/EppoValue.cs
+++ b/dot-net-sdk/dto/EppoValue.cs
@@ -1,10 +1,7 @@
-using System.Dynamic;
 using System.Globalization;
-using System.Text.Json.Nodes;
-using Common.Logging;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using NLog;
 
 namespace eppo_sdk.dto;
 
@@ -19,7 +16,6 @@ public class EppoValue
 
     private JObject? _json;
 
-
     public static EppoValue Bool(string? value) => new(value, EppoValueType.BOOLEAN);
     public static EppoValue Bool(bool value) => new(value.ToString(), EppoValueType.BOOLEAN);
     public static EppoValue Number(string value) => new(value, EppoValueType.NUMBER);
@@ -27,6 +23,9 @@ public class EppoValue
     public static EppoValue Integer(string value) => new(value, EppoValueType.INTEGER);
     public static EppoValue JsonObject(string value) => new(value, EppoValueType.JSON);
     public static EppoValue Null() => new();
+
+
+    private static readonly Logger Logger = LogManager.GetLogger("EppoValue");
 
     public EppoValue()
     {
@@ -78,8 +77,7 @@ public class EppoValue
             }
             catch (JsonReaderException)
             {
-                var log = LogManager.GetLogger<EppoValue>();
-                log.Error($"Unable to deserialize <{_json}> into a JSON obect.");
+                EppoValue.Logger.Error($"Unable to deserialize <{_json}> into a JSON obect.");
             }
         }
         return _json;

--- a/dot-net-sdk/dto/EppoValue.cs
+++ b/dot-net-sdk/dto/EppoValue.cs
@@ -75,9 +75,9 @@ public class EppoValue
             {
                 _json = JObject.Parse(Value);
             }
-            catch (JsonReaderException)
+            catch (JsonReaderException e)
             {
-                EppoValue.Logger.Error($"Unable to deserialize <{_json}> into a JSON obect.");
+                Logger.Error($"Unable to deserialize <{_json}> into a JSON obect {e.Message}.");
             }
         }
         return _json;

--- a/dot-net-sdk/dto/EppoValue.cs
+++ b/dot-net-sdk/dto/EppoValue.cs
@@ -1,16 +1,21 @@
+using System.Dynamic;
 using System.Globalization;
+using System.Text.Json.Nodes;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace eppo_sdk.dto;
 
 [JsonConverter(typeof(EppoValueDeserializer))]
 public class EppoValue
 {
-    public string? value { get; set; }
+    public string? Value { get; set; }
 
-    public EppoValueType type { get; set; } = EppoValueType.NULL;
+    public EppoValueType Type { get; set; } = EppoValueType.NULL;
 
-    public List<string>? array { get; set; }
+    private List<string>? _array;
+
+    private JObject? _json;
 
 
     public static EppoValue Bool(string? value) => new(value, EppoValueType.BOOLEAN);
@@ -18,6 +23,7 @@ public class EppoValue
     public static EppoValue Number(string value) => new(value, EppoValueType.NUMBER);
     public static EppoValue String(string? value) => new(value, EppoValueType.STRING);
     public static EppoValue Integer(string value) => new(value, EppoValueType.INTEGER);
+    public static EppoValue JsonObject(string value) => new(value, EppoValueType.JSON);
     public static EppoValue Null() => new();
 
     public EppoValue()
@@ -26,35 +32,61 @@ public class EppoValue
 
     public EppoValue(string? value, EppoValueType type)
     {
-        this.value = value;
-        this.type = type;
+        this.Value = value;
+        this.Type = type;
+
+        // This is helpful but parsing will actually not recognize JSON; it will merely see a string.
+        if (type == EppoValueType.JSON)
+        {
+            _json = JObject.Parse(value);
+        }
     }
 
     public EppoValue(List<string> array)
     {
-        this.array = array;
-        this.type = EppoValueType.ARRAY_OF_STRING;
+        this._array = array;
+        this.Type = EppoValueType.ARRAY_OF_STRING;
     }
 
-    public EppoValue(EppoValueType type) => this.type = type;
+    public EppoValue(EppoValueType type) => this.Type = type;
 
-    public bool BoolValue() => bool.Parse(value);
+    public bool BoolValue() => bool.Parse(Value);
 
-    public double DoubleValue() => double.Parse(value, NumberStyles.Number);
+    public double DoubleValue() => double.Parse(Value, NumberStyles.Number);
 
-    public int IntegerValue() => int.Parse(value, NumberStyles.Number);
+    public int IntegerValue() => int.Parse(Value, NumberStyles.Number);
 
-    public bool IsNumeric() => double.TryParse(value, out _);
+    public bool IsNumeric() => double.TryParse(Value, out _);
 
-    public string StringValue() => value;
+    public string StringValue() => Value;
 
-    public List<string> ArrayValue() => array;
+    public List<string> ArrayValue() => _array;
 
-    public bool IsNull() => EppoValueType.NULL.Equals(type);
+
+    /**
+     * Attempts to parse the value into a JObject, returns null if parsing fails.
+     */
+    public JObject? JsonValue()
+    {
+        if (_json == null && Value != null)
+        {
+            try
+            {
+                _json = JObject.Parse(Value);
+            }
+            catch (JsonReaderException)
+            {
+
+            }
+        }
+        return _json;
+    }
+
+    public bool IsNull() => EppoValueType.NULL.Equals(Type);
 
     public static bool IsNullValue(EppoValue? value) =>
      value == null /* null pointer */ ||
          value.IsNull() /* parsed as a null JSON token type */ ||
-         value.value == null; /* Value type is set but value is null */
+         value.Value == null; /* Value type is set but value is null */
 
 }

--- a/dot-net-sdk/dto/EppoValueType.cs
+++ b/dot-net-sdk/dto/EppoValueType.cs
@@ -6,6 +6,7 @@ public enum EppoValueType
     INTEGER,
     STRING,
     BOOLEAN,
+    JSON,
     NULL,
     ARRAY_OF_STRING
 }

--- a/dot-net-sdk/eppo-sdk.csproj
+++ b/dot-net-sdk/eppo-sdk.csproj
@@ -21,7 +21,6 @@
     <Folder Include="logger\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Common.Logging" Version="3.4.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/dot-net-sdk/eppo-sdk.csproj
+++ b/dot-net-sdk/eppo-sdk.csproj
@@ -21,6 +21,7 @@
     <Folder Include="logger\" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Common.Logging" Version="3.4.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/eppo-sdk-test/ValidateJsonConvertion.cs
+++ b/eppo-sdk-test/ValidateJsonConvertion.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Nodes;
 using eppo_sdk.dto;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -8,26 +7,26 @@ namespace eppo_sdk_test;
 
 public class ValidateJsonConvertion
 {
-    [Test]
-    public void ShouldConvertCondition()
-    {
-        const string json = @"{
+  [Test]
+  public void ShouldConvertCondition()
+  {
+    const string json = @"{
             'value': ['iOS','Android'],
             'operator': 'ONE_OF',
             'attribute': 'device'
         }";
-        var condition = JsonConvert.DeserializeObject<Condition>(json);
-        Multiple(() =>
-        {
-            That(condition.operatorType, Is.EqualTo(OperatorType.ONE_OF));
-            That(condition.attribute, Is.EqualTo("device"));
-        });
-    }
-
-    [Test]
-    public void ShouldConvertRules()
+    var condition = JsonConvert.DeserializeObject<Condition>(json);
+    Multiple(() =>
     {
-        const string json = @"[
+      That(condition.operatorType, Is.EqualTo(OperatorType.ONE_OF));
+      That(condition.attribute, Is.EqualTo("device"));
+    });
+  }
+
+  [Test]
+  public void ShouldConvertRules()
+  {
+    const string json = @"[
         {
           'allocationKey': 'allocation-experiment-4',
           'conditions': [{'value': ['iOS','Android'],'operator': 'ONE_OF','attribute': 'device'},
@@ -44,40 +43,69 @@ public class ValidateJsonConvertion
           ]}
       ]";
 
-        var rules = JsonConvert.DeserializeObject<List<Rule>>(json);
-        Assert.That(rules.Count, Is.EqualTo(3));
-        Assert.That(rules[0].conditions[0].operatorType, Is.EqualTo(OperatorType.ONE_OF));
-        Assert.That(rules[0].conditions[0].value.ArrayValue(), Is.EqualTo(new List<string>
+    var rules = JsonConvert.DeserializeObject<List<Rule>>(json);
+    Assert.That(rules.Count, Is.EqualTo(3));
+    Assert.That(rules[0].conditions[0].operatorType, Is.EqualTo(OperatorType.ONE_OF));
+    Assert.That(rules[0].conditions[0].value.ArrayValue(), Is.EqualTo(new List<string>
         {
             "iOS",
             "Android"
         }));
-        Assert.That(rules[0].conditions[0].attribute, Is.EqualTo("device"));
+    Assert.That(rules[0].conditions[0].attribute, Is.EqualTo("device"));
 
-        Assert.That(rules[1].conditions[0].operatorType, Is.EqualTo(OperatorType.NOT_ONE_OF));
-        Assert.That(rules[1].conditions[0].attribute, Is.EqualTo("country"));
-    }
+    Assert.That(rules[1].conditions[0].operatorType, Is.EqualTo(OperatorType.NOT_ONE_OF));
+    Assert.That(rules[1].conditions[0].attribute, Is.EqualTo("country"));
+  }
 
-    [Test]
-    public void ShouldParseJsonValueType() {
-           const string json = @"{
+  [Test]
+  public void ShouldSupportJsonValueType()
+  {
+    const string json = @"{
             'background': 'black',
             'color': 'yellow',
             'logo': '_assets/newlogo.png'
         }";
-        var value = new EppoValue(json, EppoValueType.JSON);
-        var expected = new JObject {
-          ["background"]= "black",
-          ["color"] = "yellow",
-          ["logo"] = "_assets/newlogo.png"
-        };
-        Multiple(() =>
-        {
-            That(value.Value, Is.EqualTo(json));
-            That(value.Type, Is.EqualTo(EppoValueType.JSON));
-            That(value.JsonValue(), Is.EqualTo(expected));
-            
-        });
-    }
+    var value = new EppoValue(json, EppoValueType.JSON);
+    var expected = new JObject
+    {
+      ["background"] = "black",
+      ["color"] = "yellow",
+      ["logo"] = "_assets/newlogo.png"
+    };
+    Multiple(() =>
+    {
+      That(value.Value, Is.EqualTo(json));
+      That(value.Type, Is.EqualTo(EppoValueType.JSON));
+      That(value.JsonValue(), Is.EqualTo(expected));
+
+    });
+  }
+  [Test]
+  public void ShouldParseJsonValueType()
+  {
+    const string json = @"{
+            'shardRange': {
+              'start': 0,
+              'end': 10000
+            },
+            'typedValue': ""'background': 'black','color': 'yellow','logo': '_assets/newlogo.png'}""
+        }";
+    var variation = JsonConvert.DeserializeObject<Variation>(json);
+    var value = variation.typedValue;
+    var expected = new JObject
+    {
+      ["background"] = "black",
+      ["color"] = "yellow",
+      ["logo"] = "_assets/newlogo.png"
+    };
+    Multiple(() =>
+    {
+      That(variation, Is.Not.Null);
+      That(value, Is.Not.Null);
+      // That(value.Value, Is.EqualTo(json));
+      That(value.Type, Is.EqualTo(EppoValueType.STRING));
+      That(value.JsonValue(), Is.EqualTo(expected));
+    });
+  }
 
 }

--- a/eppo-sdk-test/ValidateJsonConvertion.cs
+++ b/eppo-sdk-test/ValidateJsonConvertion.cs
@@ -1,5 +1,7 @@
+using System.Text.Json.Nodes;
 using eppo_sdk.dto;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using static NUnit.Framework.Assert;
 
 namespace eppo_sdk_test;
@@ -55,4 +57,27 @@ public class ValidateJsonConvertion
         Assert.That(rules[1].conditions[0].operatorType, Is.EqualTo(OperatorType.NOT_ONE_OF));
         Assert.That(rules[1].conditions[0].attribute, Is.EqualTo("country"));
     }
+
+    [Test]
+    public void ShouldParseJsonValueType() {
+           const string json = @"{
+            'background': 'black',
+            'color': 'yellow',
+            'logo': '_assets/newlogo.png'
+        }";
+        var value = new EppoValue(json, EppoValueType.JSON);
+        var expected = new JObject {
+          ["background"]= "black",
+          ["color"] = "yellow",
+          ["logo"] = "_assets/newlogo.png"
+        };
+        Multiple(() =>
+        {
+            That(value.Value, Is.EqualTo(json));
+            That(value.Type, Is.EqualTo(EppoValueType.JSON));
+            That(value.JsonValue(), Is.EqualTo(expected));
+            
+        });
+    }
+
 }

--- a/eppo-sdk-test/ValidateJsonConvertion.cs
+++ b/eppo-sdk-test/ValidateJsonConvertion.cs
@@ -88,7 +88,7 @@ public class ValidateJsonConvertion
               'start': 0,
               'end': 10000
             },
-            'typedValue': ""'background': 'black','color': 'yellow','logo': '_assets/newlogo.png'}""
+            'typedValue': ""{'background': 'black','color': 'yellow','logo': '_assets/newlogo.png'}""
         }";
     var variation = JsonConvert.DeserializeObject<Variation>(json);
     var value = variation.typedValue;
@@ -102,7 +102,7 @@ public class ValidateJsonConvertion
     {
       That(variation, Is.Not.Null);
       That(value, Is.Not.Null);
-      // That(value.Value, Is.EqualTo(json));
+      // When parsing a payload, the JSON object is actually encoded as a string.
       That(value.Type, Is.EqualTo(EppoValueType.STRING));
       That(value.JsonValue(), Is.EqualTo(expected));
     });


### PR DESCRIPTION
This change is pretty basic - it adds an enum value, allows EppoValue to parse into a new data type (JSON) and exposes that method `JsonValue` through `EppoClient`. In addition to this, there's some code formatting change that made for some tedious diffs.

Of note: JSON variation values are sent over the wire as double json-encoded as it is sent as a string within the larger JSON-encoded RAC or UFC data structure. Because of this, the parsing layer of the SDK sees it as a string and has no idea that it's supposed to be a structure. The `VariationType` is transmitted in the new UFC schema, but is unavailable to the DTO parsing logic. It turns out that this is OK anyway. The `EppoValue.Type` field is never read and there is not currently any type checking of what the user asks for (ex `GetStringAssignment` and what type the value actually is (though this may be implemented in the UFC updates as it has been in other SDKs).
