### PR TITLE
feat: update EppoClient to handle empty actions

### DIFF
--- a/dot-net-sdk/EppoClient.cs
+++ b/dot-net-sdk/EppoClient.cs
@@ -408,14 +408,14 @@ public class EppoClient
             && _configurationStore.GetBanditFlags().TryGetBanditKey(flagKey, variation, out string? banditKey)
             && banditKey != null)
         {
-            result = EvaluateAndLogBandit(banditKey, flagKey, subject, actions, variation);
+            result = EvaluateAndLogBandit(banditKey!, flagKey, subject, actions, variation);
         }
 
         return result ?? new(variation);
 
     }
 
-    private BanditResult? EvaluateAndLogBandit(string? banditKey,
+    private BanditResult? EvaluateAndLogBandit(string banditKey,
                                                string flagKey,
                                                ContextAttributes subject,
                                                IDictionary<string, ContextAttributes> actions,
@@ -448,7 +448,7 @@ public class EppoClient
             else
             {
                 // There should be a bandit matching `banditKey`, but there is not, and that's a problem.
-                Logger.Error($"[Eppo SDK] Bandit model {banditKey} not found");
+                Logger.Error($"[Eppo SDK] Bandit model {banditKey} not found for {flagKey} {variation}");
             }
         }
         catch (BanditEvaluationException bee)

--- a/dot-net-sdk/dto/BanditFlags.cs
+++ b/dot-net-sdk/dto/BanditFlags.cs
@@ -1,12 +1,34 @@
+using System.Collections.Specialized;
 using eppo_sdk.dto.bandit;
 
 namespace eppo_sdk.dto;
 
-public interface IBanditFlags: IDictionary<string, BanditVariation[]> {
+public interface IBanditFlags : IDictionary<string, BanditVariation[]>
+{
     public bool IsBanditFlag(string FlagKey);
+
+    public bool TryGetBanditKey(string FlagKey, string VariationValue, out string? BanditKey);
 }
 
 public class BanditFlags : Dictionary<string, BanditVariation[]>, IBanditFlags
 {
-    public bool IsBanditFlag(string flagKey) => this.Any(kvp=> kvp.Value.Any(bv => bv.FlagKey == flagKey));
+    public bool IsBanditFlag(string flagKey) => this.Any(kvp => kvp.Value.Any(bv => bv.FlagKey == flagKey));
+
+    public bool TryGetBanditKey(string FlagKey, string variationValue, out string? banditKey)
+    {
+        banditKey = null;
+        try
+        {
+            var banditRef = this.First(kvp => kvp.Value.Any(bv => bv.FlagKey == FlagKey && bv.VariationValue == variationValue));
+
+            var banditVariation = banditRef.Value.First(bv => bv.FlagKey == FlagKey && bv.VariationValue == variationValue);
+            banditKey = banditVariation.Key;
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            // Thrown when no matching elements are found above; do nothing.
+        }
+        return false;
+    }
 }

--- a/dot-net-sdk/dto/BanditFlags.cs
+++ b/dot-net-sdk/dto/BanditFlags.cs
@@ -1,4 +1,3 @@
-using System.Collections.Specialized;
 using eppo_sdk.dto.bandit;
 
 namespace eppo_sdk.dto;
@@ -7,21 +6,21 @@ public interface IBanditFlags : IDictionary<string, BanditVariation[]>
 {
     public bool IsBanditFlag(string FlagKey);
 
-    public bool TryGetBanditKey(string FlagKey, string VariationValue, out string? BanditKey);
+    public bool TryGetBanditKey(string flagKey, string VariationValue, out string? BanditKey);
 }
 
 public class BanditFlags : Dictionary<string, BanditVariation[]>, IBanditFlags
 {
     public bool IsBanditFlag(string flagKey) => this.Any(kvp => kvp.Value.Any(bv => bv.FlagKey == flagKey));
 
-    public bool TryGetBanditKey(string FlagKey, string variationValue, out string? banditKey)
+    public bool TryGetBanditKey(string flagKey, string variationValue, out string? banditKey)
     {
         banditKey = null;
         try
         {
-            var banditRef = this.First(kvp => kvp.Value.Any(bv => bv.FlagKey == FlagKey && bv.VariationValue == variationValue));
+            var banditRef = this.First(kvp => kvp.Value.Any(bv => bv.FlagKey == flagKey && bv.VariationValue == variationValue));
 
-            var banditVariation = banditRef.Value.First(bv => bv.FlagKey == FlagKey && bv.VariationValue == variationValue);
+            var banditVariation = banditRef.Value.First(bv => bv.FlagKey == flagKey && bv.VariationValue == variationValue);
             banditKey = banditVariation.Key;
             return true;
         }

--- a/eppo-sdk-test/BanditClientTest.cs
+++ b/eppo-sdk-test/BanditClientTest.cs
@@ -26,6 +26,13 @@ public class BanditClientTest
         {"age", 30},
         {"country", "UK"}
     };
+    private ContextAttributes _AmerSubject = new("subject_key")
+    {
+        {"account_age", 3},
+        {"favourite_colour", "red"},
+        {"age", 30},
+        {"country", "USA"}
+    };
     private readonly Dictionary<string, ContextAttributes> _actions = new()
     {
         {"action1" , new("action1") {
@@ -96,7 +103,7 @@ public class BanditClientTest
     }
 
     [Test]
-    public void ShouldReturnDefaultForNonBandit()
+    public void ShouldReturnDefaultForUnknownFlag()
     {
         var client = CreateClient();
         var result = client.GetBanditAction("unknownflag", _subject, _actions, "defaultVariation");
@@ -109,14 +116,14 @@ public class BanditClientTest
     }
 
     [Test]
-    public void ShouldReturnDefaultForNonBanditFlag()
+    public void ShouldReturnVariationForNonBanditFlag()
     {
         var client = CreateClient();
-        var result = client.GetBanditAction("a_flag", _subject, new Dictionary<string, ContextAttributes>(), "default_variation");
+        var result = client.GetBanditAction("non_bandit_flag", _subject, new Dictionary<string, ContextAttributes>(), "defaultVariation");
         Multiple(() =>
         {
             That(result, Is.Not.Null);
-            That(result.Variation, Is.EqualTo("default_variation"));
+            That(result.Variation, Is.EqualTo("control"));
             That(result.Action, Is.Null);
         });
     }
@@ -159,7 +166,7 @@ public class BanditClientTest
             }
         };
 
-        var defaultVariation = "default_variation";
+        var defaultVariation = "defaultVariation";
 
 
         // Act
@@ -233,7 +240,7 @@ public class BanditClientTest
         var defaultSubjectAttributes = _subject.AsDict();
         var actions = new string[] { "adidas", "nike", "Reebok" };
 
-        var defaultVariation = "default_variation";
+        var defaultVariation = "defaultVariation";
 
 
         // Act
@@ -296,9 +303,8 @@ public class BanditClientTest
     }
 
     [Test]
-    public void ShouldReturnDefaultForNoActions()
+    public void ShouldReturnVariationForNoActions()
     {
-
         var mockLogger = new Mock<IAssignmentLogger>();
         var client = CreateClient(mockLogger.Object);
 
@@ -306,20 +312,20 @@ public class BanditClientTest
         Multiple(() =>
         {
             That(result, Is.Not.Null);
-            That(result.Variation, Is.EqualTo("defaultValue"));
+            That(result.Variation, Is.EqualTo("banner_bandit"));
             That(result.Action, Is.Null);
             That(mockLogger.Invocations, Is.Empty);
         });
     }
 
     [Test]
-    public void ShouldReturnVariationForNonBandit()
+    public void ShouldReturnNonBanditVariation()
     {
         var mockLogger = new Mock<IAssignmentLogger>();
         mockLogger.Setup(mock => mock.LogAssignment(It.IsAny<AssignmentLogData>()));
         var client = CreateClient(mockLogger.Object);
 
-        var result = client.GetBanditAction("non_bandit_flag", _subject, new Dictionary<string, ContextAttributes>(), "defaultValue");
+        var result = client.GetBanditAction("banner_bandit_flag_uk_only", _AmerSubject, new Dictionary<string, ContextAttributes>(), "defaultValue");
 
         Multiple(() =>
         {

--- a/eppo-sdk-test/BanditClientTest.cs
+++ b/eppo-sdk-test/BanditClientTest.cs
@@ -18,7 +18,7 @@ public class BanditClientTest
 {
     private const string BANDIT_CONFIG_FILE = "files/ufc/bandit-flags-v1.json";
     private const string BANDIT_MODEL_FILE = "files/ufc/bandit-models-v1.json";
-    private WireMockServer? mockeServer;
+    private WireMockServer? mockServer;
     private readonly ContextAttributes subject = new("subject_key")
     {
         {"account_age", 3},
@@ -61,7 +61,7 @@ public class BanditClientTest
         }
         var config = new EppoClientConfig("mock-api-key", logger)
         {
-            BaseUrl = mockeServer?.Urls[0]!
+            BaseUrl = mockServer?.Urls[0]!
         };
         return EppoClient.Init(config);
     }
@@ -74,12 +74,12 @@ public class BanditClientTest
 
     private void SetupMockServer()
     {
-        mockeServer = WireMockServer.Start();
-        Console.WriteLine($"MockServer started at: {mockeServer.Urls[0]}");
-        this.mockeServer
+        mockServer = WireMockServer.Start();
+        Console.WriteLine($"MockServer started at: {mockServer.Urls[0]}");
+        this.mockServer
             .Given(Request.Create().UsingGet().WithPath(new RegexMatcher("flag-config/v1/config")))
             .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.OK).WithBody(GetMockBanditConfig()).WithHeader("Content-Type", "application/json"));
-        this.mockeServer
+        this.mockServer
             .Given(Request.Create().UsingGet().WithPath(new RegexMatcher("flag-config/v1/bandits")))
             .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.OK).WithBody(GetMockBanditModelConfig()).WithHeader("Content-Type", "application/json"));
     }
@@ -87,7 +87,7 @@ public class BanditClientTest
     [OneTimeTearDown]
     public void TearDown()
     {
-        mockeServer?.Stop();
+        mockServer?.Stop();
     }
 
     private static string GetMockBanditConfig() => GetMockConfig(BANDIT_CONFIG_FILE);

--- a/eppo-sdk-test/dto/BanditFlagsTest.cs
+++ b/eppo-sdk-test/dto/BanditFlagsTest.cs
@@ -1,6 +1,8 @@
 
 using eppo_sdk.dto;
 using eppo_sdk.dto.bandit;
+using GraphQL.Introspection;
+using NLog.Targets.Wrappers;
 using static NUnit.Framework.Assert;
 
 namespace eppo_sdk_test.dto;
@@ -8,17 +10,21 @@ namespace eppo_sdk_test.dto;
 
 public class BanditFlagsTest
 {
+    private BanditFlags banditFlags;
+    [SetUp]
+    public void SetUp()
+    {
+        banditFlags = new BanditFlags()
+        {
+            // Typical `BanditVariationDto` values where `variation` is duplicated across the VariationValue, VariationKey and BanditKey fields.
+            ["variation"] = new BanditVariation[] { new("variation", "banditFlagKey", "variation", "variation") },
+
+            ["banditKey"] = new BanditVariation[] { new("banditKey", "flagKey", "variationKey", "variationValue") }
+        };
+    }
     [Test]
     public void ShouldIndicateBanditFlags()
     {
-        var banditFlags = new BanditFlags()
-        {
-            // Typical `BanditVariationDto` values where `variation` is duplicated across the VariationValue, VariationKey and BanditKey fields.
-            ["variation"] = new BanditVariation[] {new("variation", "banditFlagKey", "variation", "variation")},
-
-            ["banditKey"] = new BanditVariation[] {new("banditKey", "flagKey", "variationKey", "variationValue")}
-        };
-
         Multiple(() =>
         {
             That(banditFlags.IsBanditFlag("notAFlag"), Is.False);
@@ -28,6 +34,33 @@ public class BanditFlagsTest
             That(banditFlags.IsBanditFlag("variationKey"), Is.False);
             That(banditFlags.IsBanditFlag("variationValue"), Is.False);
             That(banditFlags.IsBanditFlag("flagKey"), Is.True);
+        });
+    }
+
+    [Test]
+    public void ShouldReturnFalseIfNotABanditVariation()
+    {
+        Multiple(() =>
+        {
+            // Neither match
+            That(banditFlags.TryGetBanditKey("notAFlag", "notAVaration", out string? _), Is.False);
+            // flag key is valid, but variation doesn't match
+            That(banditFlags.TryGetBanditKey("flagKey", "notAVaration", out string? _), Is.False);
+            // variation matches a bandit but the flag does not.
+            That(banditFlags.TryGetBanditKey("notAFlag", "variation", out string? _), Is.False);
+        });
+    }
+
+    [Test]
+    public void ShouldLookupBanditKey()
+    {
+        Multiple(() =>
+        {
+            That(banditFlags.TryGetBanditKey("flagKey", "variationValue", out string? key1), Is.True);
+            That(key1, Is.EqualTo("banditKey"));
+
+            That(banditFlags.TryGetBanditKey("banditFlagKey", "variation", out string? key2), Is.True);
+            That(key2, Is.EqualTo("variation"));
         });
     }
 }

--- a/eppo-sdk-test/validators/BanditEvaluatorTest.cs
+++ b/eppo-sdk-test/validators/BanditEvaluatorTest.cs
@@ -339,7 +339,6 @@ public class BanditEvaluatorTest
                 }
             },
             {
-                // Note: Anot
                 "action2", new ActionCoefficients("action2", 0.3)
                 {
                     SubjectNumericCoefficients = new List<NumericAttributeCoefficient>() { new("age", 0.1, 0.0) },


### PR DESCRIPTION
fixes FF-2874
[slack 🧵 ](https://fluxonapps.slack.com/archives/C05R6BK5BB9/p1721149341928549)

### Motivation and Context
An empty action list should not prevent the computation of a string assignment, even if that assignment maps to a bandit but no actions are provided.

### Description
- Always evaluate the string assignment and only use a non-empty action list to gate whether or not a bandit is processed
- Change `BanditFlags` to lookup banditKey based on variation and flag key. (While the `VariationValue` is de-facto equivalent to the **bandit key**, the mapping is actually (variation, flagKey) => banditKey and this change corrects that shortcoming in this SDK

### Testing?
You bet! Improved unit tests and now passing the universal tests for this very scenario