### PR TITLE
feat: Only load bandits if they are referenced by flags

### DIFF
--- a/eppo-sdk-test/store/ConfigurationStoreTest.cs
+++ b/eppo-sdk-test/store/ConfigurationStoreTest.cs
@@ -82,7 +82,12 @@ public class ConfigurationStoreTest
         var store = CreateConfigurationStore(mockRequester.Object);
         store.LoadConfiguration();
 
-        Assert.That(store.GetBanditFlags(), Is.EqualTo(banditFlags));
+        Assert.Multiple(() =>
+        {
+            Assert.That(store.GetBanditFlags(), Is.EqualTo(banditFlags));
+            Assert.That(store.TryGetBandit("banditKey", out Bandit? bandit), Is.False);
+            Assert.That(bandit, Is.Null);
+        });
         mockRequester.Verify(m => m.FetchBanditModels(), Times.Never());
     }
 

--- a/eppo-sdk-test/store/ConfigurationStoreTest.cs
+++ b/eppo-sdk-test/store/ConfigurationStoreTest.cs
@@ -5,6 +5,7 @@ using eppo_sdk.helpers;
 using eppo_sdk.http;
 using eppo_sdk.store;
 using Moq;
+using NUnit.Framework.Internal;
 using static NUnit.Framework.Assert;
 
 
@@ -25,6 +26,44 @@ public class ConfigurationStoreTest
     [Test]
     public void ShouldStoreAndGetBanditFlags()
     {
+        var banditFlags = new BanditFlags()
+        {
+            ["banditKey"] = new BanditVariation[] { new("banditKey", "flagKey", "variationKey", "variationValue")
+        }
+        };
+        var response = new FlagConfigurationResponse()
+        {
+            Bandits = banditFlags,
+            Flags = new Dictionary<string, Flag>()
+        };
+        var banditResponse = new BanditModelResponse()
+        {
+            Bandits = new Dictionary<string, Bandit>()
+            {
+                ["banditKey"] = new Bandit("banditKey", "falcon", DateTime.Now, "v123", new ModelData()
+                {
+                    Coefficients = new Dictionary<string, ActionCoefficients>()
+                }),
+            }
+        };
+
+        var mockRequester = new Mock<IConfigurationRequester>();
+        mockRequester.Setup(m => m.FetchFlagConfiguration()).Returns(response);
+        mockRequester.Setup(m => m.FetchBanditModels()).Returns(banditResponse);
+
+        var store = CreateConfigurationStore(mockRequester.Object);
+        store.LoadConfiguration();
+        Assert.Multiple(() =>
+        {
+            Assert.That(store.GetBanditFlags(), Is.EqualTo(banditFlags));
+            Assert.That(store.TryGetBandit("banditKey", out Bandit? bandit), Is.True);
+            Assert.That(bandit, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void ShouldOnlyGetBanditModelsIfReferenced()
+    {
         var banditFlags = new BanditFlags();
         var response = new FlagConfigurationResponse()
         {
@@ -44,6 +83,7 @@ public class ConfigurationStoreTest
         store.LoadConfiguration();
 
         Assert.That(store.GetBanditFlags(), Is.EqualTo(banditFlags));
+        mockRequester.Verify(m => m.FetchBanditModels(), Times.Never());
     }
 
     [Test]
@@ -122,7 +162,7 @@ public class ConfigurationStoreTest
         AssertHasFlag(store, "flag1");
         AssertHasFlag(store, "flag3");
         AssertHasFlag(store, "flag2", false);
-    
+
 
         store.SetConfiguration(Array.Empty<Flag>(), null, null);
 


### PR DESCRIPTION
fixes  FF-2873

### Motivation And Context
Bandits are used by only a few customers. The current implementation loads bandits on every config refresh, doubling the number of network requests.

### Description of changes
- check the Bandits referenced in the UFC response and only if not empty, load the bandit models.
### Testing
updated unit tests