### PR TITLE
store, send ETAG and only apply config if modified

### DIFF
--- a/dot-net-sdk/http/ConfigurationRequester.cs
+++ b/dot-net-sdk/http/ConfigurationRequester.cs
@@ -4,24 +4,26 @@ using NLog;
 
 namespace eppo_sdk.http;
 
-public interface IConfigurationRequester {
-    public FlagConfigurationResponse? FetchFlagConfiguration();
-    public BanditModelResponse? FetchBanditModels();
+public interface IConfigurationRequester
+{
+    public VersionedResource<FlagConfigurationResponse>? FetchFlagConfiguration(string? lastEtag = null);
+    public VersionedResource<BanditModelResponse>? FetchBanditModels();
 }
 public class ConfigurationRequester : IConfigurationRequester
 {
     private static Logger logger = LogManager.GetCurrentClassLogger();
     private readonly EppoHttpClient eppoHttpClient;
 
-    public ConfigurationRequester(EppoHttpClient eppoHttpClient) {
+    public ConfigurationRequester(EppoHttpClient eppoHttpClient)
+    {
         this.eppoHttpClient = eppoHttpClient;
     }
 
-    public FlagConfigurationResponse? FetchFlagConfiguration()
+    public VersionedResource<FlagConfigurationResponse>? FetchFlagConfiguration(string? lastEtag = null)
     {
         try
         {
-            return this.eppoHttpClient.Get<FlagConfigurationResponse>(Constants.UFC_ENDPOINT);
+            return eppoHttpClient.Get<FlagConfigurationResponse>(Constants.UFC_ENDPOINT, lastEtag);
         }
         catch (Exception e)
         {
@@ -31,11 +33,11 @@ public class ConfigurationRequester : IConfigurationRequester
         return null;
     }
 
-    public BanditModelResponse? FetchBanditModels()
+    public VersionedResource<BanditModelResponse>? FetchBanditModels()
     {
         try
         {
-            return this.eppoHttpClient.Get<BanditModelResponse>(Constants.BANDIT_ENDPOINT);
+            return eppoHttpClient.Get<BanditModelResponse>(Constants.BANDIT_ENDPOINT);
         }
         catch (Exception e)
         {

--- a/dot-net-sdk/http/EppoHttpClient.cs
+++ b/dot-net-sdk/http/EppoHttpClient.cs
@@ -7,11 +7,11 @@ namespace eppo_sdk.http;
 
 public class VersionedResource<RType>
 {
-    public readonly RType Resource;
+    public readonly RType? Resource;
     public readonly bool IsModified;
     public readonly string? ETag;
 
-    public VersionedResource(RType resource, string? eTag = null, bool isModified = true)
+    public VersionedResource(RType? resource, string? eTag = null, bool isModified = true)
     {
         Resource = resource;
         IsModified = isModified;
@@ -54,12 +54,12 @@ public class EppoHttpClient
         this._defaultParams.Add(key, value);
     }
 
-    public VersionedResource<RType>? Get<RType>(string url, string? lastVersion = null)
+    public VersionedResource<RType> Get<RType>(string url, string? lastVersion = null)
     {
         return this.Get<RType>(url, new Dictionary<string, string>(), new Dictionary<string, string>(), lastVersion);
     }
 
-    public VersionedResource<RType>? Get<RType>(
+    public VersionedResource<RType> Get<RType>(
         string url,
         Dictionary<string, string> parameters,
         Dictionary<string, string> headers,
@@ -77,7 +77,7 @@ public class EppoHttpClient
 
         if (lastVersion != null)
         {
-            headers.Add("IF-NONE-MATCHES", lastVersion);
+            headers.Add("IF-NONE-MATCH", lastVersion);
         }
         request.AddHeaders(headers);
 
@@ -98,8 +98,6 @@ public class EppoHttpClient
         {
             eTag = null;
         }
-        if (restResponse.Data == null) { return null; }
-
         return new VersionedResource<RType>(restResponse.Data, eTag, eTag == null || eTag != lastVersion);
     }
 }

--- a/dot-net-sdk/store/ConfigurationStore.cs
+++ b/dot-net-sdk/store/ConfigurationStore.cs
@@ -158,22 +158,26 @@ public class ConfigurationStore : IConfigurationStore
 
     private VersionedResource<FlagConfigurationResponse> FetchFlags(string? lastEtag = null)
     {
-        var response = _requester.FetchFlagConfiguration(lastEtag);
-        if (response != null)
+        try
         {
-            return response;
+            return _requester.FetchFlagConfiguration(lastEtag);
         }
+        catch (Exception e)
+        {
 
-        throw new SystemException("Unable to fetch flag configuration");
+            throw new SystemException("Unable to fetch flag configuration" + e.Message);
+        }
     }
     private VersionedResource<BanditModelResponse> FetchBandits()
     {
-        var response = _requester.FetchBanditModels();
-        if (response != null)
+        try
         {
-            return response;
+            return _requester.FetchBanditModels();
         }
+        catch (Exception e)
+        {
 
-        throw new SystemException("Unable to fetch bandit models");
+            throw new SystemException("Unable to fetch bandit configuration" + e.Message);
+        }
     }
 }

--- a/eppo-sdk-test/store/ConfigurationStoreTest.cs
+++ b/eppo-sdk-test/store/ConfigurationStoreTest.cs
@@ -4,6 +4,8 @@ using eppo_sdk.dto.bandit;
 using eppo_sdk.helpers;
 using eppo_sdk.http;
 using eppo_sdk.store;
+using GraphQL.Introspection;
+using Microsoft.Extensions.Caching.Memory;
 using Moq;
 using static NUnit.Framework.Assert;
 
@@ -17,9 +19,9 @@ public class ConfigurationStoreTest
     {
         var configCache = new CacheHelper(Constants.MAX_CACHE_ENTRIES).Cache;
         var modelCache = new CacheHelper(Constants.MAX_CACHE_ENTRIES).Cache;
-        var banditFlagCache = new CacheHelper(Constants.MAX_CACHE_ENTRIES).Cache;
+        var metadataCache = new CacheHelper(Constants.MAX_CACHE_ENTRIES).Cache;
 
-        return new ConfigurationStore(requester, configCache, modelCache, banditFlagCache);
+        return new ConfigurationStore(requester, configCache, modelCache, metadataCache);
     }
 
     [Test]
@@ -37,13 +39,75 @@ public class ConfigurationStoreTest
         };
 
         var mockRequester = new Mock<IConfigurationRequester>();
-        mockRequester.Setup(m => m.FetchFlagConfiguration()).Returns(response);
-        mockRequester.Setup(m => m.FetchBanditModels()).Returns(banditResponse);
+        mockRequester.Setup(m => m.FetchFlagConfiguration(It.IsAny<string>())).Returns(new VersionedResource<FlagConfigurationResponse>(response));
+        mockRequester.Setup(m => m.FetchBanditModels()).Returns(new VersionedResource<BanditModelResponse>(banditResponse));
 
         var store = CreateConfigurationStore(mockRequester.Object);
         store.LoadConfiguration();
 
         Assert.That(store.GetBanditFlags(), Is.EqualTo(banditFlags));
+    }
+
+    [Test]
+    public void ShouldSendIfNonMatchesHeaderWithLastEtag()
+    {
+        var banditFlags = new BanditFlags();
+        var response = new FlagConfigurationResponse()
+        {
+            Bandits = banditFlags,
+            Flags = new Dictionary<string, Flag>()
+        };
+        var banditResponse = new BanditModelResponse()
+        {
+            Bandits = new Dictionary<string, Bandit>()
+        };
+
+        var mockRequester = new Mock<IConfigurationRequester>();
+        mockRequester.Setup(m => m.FetchFlagConfiguration(It.IsAny<string>())).Returns(new VersionedResource<FlagConfigurationResponse>(response, "ETAG"));
+        mockRequester.Setup(m => m.FetchBanditModels()).Returns(new VersionedResource<BanditModelResponse>(banditResponse));
+
+        var store = CreateConfigurationStore(mockRequester.Object);
+        store.LoadConfiguration();
+        mockRequester.Verify(m => m.FetchFlagConfiguration(null), Times.Exactly(1));
+
+        // ETAG should be set for second call
+        store.LoadConfiguration();
+        mockRequester.Verify(m => m.FetchFlagConfiguration("ETAG"), Times.Exactly(1));
+    }
+
+    [Test]
+    public void ShouldNotSetConfigIfNotModified()
+    {
+        var configCache = new CacheHelper(Constants.MAX_CACHE_ENTRIES).Cache;
+        var modelCache = new CacheHelper(Constants.MAX_CACHE_ENTRIES).Cache;
+        var metadataCache = new CacheHelper(Constants.MAX_CACHE_ENTRIES).Cache;
+
+        var banditFlags = new BanditFlags();
+        var response = new FlagConfigurationResponse()
+        {
+            Bandits = banditFlags,
+            Flags = new Dictionary<string, Flag>()
+            {
+                ["flag1"] = new Flag("flag1", true, new List<Allocation>(), EppoValueType.STRING, new Dictionary<string, Variation>(), 10_000)
+            }
+        };
+        var banditResponse = new BanditModelResponse()
+        {
+            Bandits = new Dictionary<string, Bandit>()
+        };
+
+        var mockRequester = new Mock<IConfigurationRequester>();
+        mockRequester.Setup(m => m.FetchFlagConfiguration(It.IsAny<string>())).Returns(new VersionedResource<FlagConfigurationResponse>(response, "ETAG", isModified: false));
+
+        var store = new ConfigurationStore(mockRequester.Object, configCache, modelCache, metadataCache);
+
+        store.LoadConfiguration();
+        Assert.Multiple(() =>
+        {
+            Assert.That(configCache, Is.Empty);
+            Assert.That(store.TryGetFlag("flag1", out Flag? flag), Is.False);
+            Assert.That(flag, Is.Null);
+        });
     }
 
     [Test]
@@ -72,8 +136,8 @@ public class ConfigurationStoreTest
         };
 
         var mockRequester = new Mock<IConfigurationRequester>();
-        mockRequester.Setup(m => m.FetchFlagConfiguration()).Returns(response);
-        mockRequester.Setup(m => m.FetchBanditModels()).Returns(banditResponse);
+        mockRequester.Setup(m => m.FetchFlagConfiguration(It.IsAny<string>())).Returns(new VersionedResource<FlagConfigurationResponse>(response));
+        mockRequester.Setup(m => m.FetchBanditModels()).Returns(new VersionedResource<BanditModelResponse>(banditResponse));
 
         var store = CreateConfigurationStore(mockRequester.Object);
         store.LoadConfiguration();
@@ -82,11 +146,13 @@ public class ConfigurationStoreTest
 
         // Now, reload the config with new BanditFlags.
 
-        mockRequester.Setup(m => m.FetchFlagConfiguration()).Returns(new FlagConfigurationResponse()
-        {
-            Bandits = banditFlags2,
-            Flags = new Dictionary<string, Flag>()
-        });
+        mockRequester.Setup(m => m.FetchFlagConfiguration(It.IsAny<string>())).Returns(
+            new VersionedResource<FlagConfigurationResponse>(
+                new FlagConfigurationResponse()
+                {
+                    Bandits = banditFlags2,
+                    Flags = new Dictionary<string, Flag>()
+                }));
 
         store.LoadConfiguration();
 
@@ -122,7 +188,7 @@ public class ConfigurationStoreTest
         AssertHasFlag(store, "flag1");
         AssertHasFlag(store, "flag3");
         AssertHasFlag(store, "flag2", false);
-    
+
 
         store.SetConfiguration(Array.Empty<Flag>(), null, null);
 


### PR DESCRIPTION
fixes FF-2728

### Motivation and Context
The API server now includes an `ETag` header to indicate what "version" of the resource it is serving. We can use this value to tell the server not to bother sending a response body if it has't changed, saving the SDK from having to parse the response and response size (since the body would be empty)

### Description
- Store the last ETag received in the renamed banditFlagCache (now `metadataCache`).
- Send the ETag string in the IF-NONE-MATCH, compute whether the resource has been modified using the eTag.

### How is this tested?
Unit tests