### PR TITLE
fix: tie-break top score by sorting by action name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help: Makefile
 testDataDir := eppo-sdk-test/files
 tempDir := ${testDataDir}/temp
 gitDataDir := ${tempDir}/sdk-test-data
-branchName := main
+branchName := tp/fix/newflag
 githubRepoLink := https://github.com/Eppo-exp/sdk-test-data.git
 
 .PHONY: test-data

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help: Makefile
 testDataDir := eppo-sdk-test/files
 tempDir := ${testDataDir}/temp
 gitDataDir := ${tempDir}/sdk-test-data
-branchName := tp/fix/newflag
+branchName := main
 githubRepoLink := https://github.com/Eppo-exp/sdk-test-data.git
 
 .PHONY: test-data

--- a/dot-net-sdk/validators/BanditEvaluator.cs
+++ b/dot-net-sdk/validators/BanditEvaluator.cs
@@ -105,13 +105,6 @@ public class BanditEvaluator
     {
         var numberOfActions = actionScores.Count;
 
-        // var bestAction = actionScores.Aggregate((currentmax, next) =>
-        // {
-        //     if (currentmax.Value == next.Value) {
-        //         return currentmax.Key.CompareTo(next.Key) < 0 ? currentmax : next;
-        //     }
-        //     return currentmax.Value > next.Value ? currentmax : next;
-        // });
         // Order by key then by value to get the highest score, tie broken by action key.
         var bestAction = actionScores.ToList().OrderByDescending(action=>action.Value).ThenBy(action=>action.Key).First();
 

--- a/dot-net-sdk/validators/BanditEvaluator.cs
+++ b/dot-net-sdk/validators/BanditEvaluator.cs
@@ -105,7 +105,9 @@ public class BanditEvaluator
     {
         var numberOfActions = actionScores.Count;
 
-        var bestAction = actionScores.Aggregate((currentmax, next) => currentmax.Value > next.Value ? currentmax : next);
+        // var bestAction = actionScores.Aggregate((currentmax, next) => currentmax.Value > next.Value ? currentmax : next);
+        // Order by key then by value to get the highest score, tie broken by action key.
+        var bestAction = actionScores.ToList().OrderByDescending(action=>action.Value).ThenBy(action=>action.Key).First();
 
         var minProbability = probabilityFloor / numberOfActions;
 

--- a/dot-net-sdk/validators/BanditEvaluator.cs
+++ b/dot-net-sdk/validators/BanditEvaluator.cs
@@ -105,7 +105,13 @@ public class BanditEvaluator
     {
         var numberOfActions = actionScores.Count;
 
-        // var bestAction = actionScores.Aggregate((currentmax, next) => currentmax.Value > next.Value ? currentmax : next);
+        // var bestAction = actionScores.Aggregate((currentmax, next) =>
+        // {
+        //     if (currentmax.Value == next.Value) {
+        //         return currentmax.Key.CompareTo(next.Key) < 0 ? currentmax : next;
+        //     }
+        //     return currentmax.Value > next.Value ? currentmax : next;
+        // });
         // Order by key then by value to get the highest score, tie broken by action key.
         var bestAction = actionScores.ToList().OrderByDescending(action=>action.Value).ThenBy(action=>action.Key).First();
 


### PR DESCRIPTION
awesome set of tests triggering this bug [PR](https://github.com/Eppo-exp/sdk-test-data/pull/52)