### PR TITLE
fix/ff 3389

### DIFF
--- a/dot-net-sdk/dto/AssignmentLogData.cs
+++ b/dot-net-sdk/dto/AssignmentLogData.cs
@@ -30,7 +30,7 @@ public record AssignmentLogData : ISerializable
         this.FeatureFlag = featureFlag;
         this.Allocation = allocation;
         this.Variation = variation;
-        this.Timestamp = new DateTime();
+        this.Timestamp = DateTime.UtcNow;
         this.Subject = subject;
         this.SubjectAttributes = subjectAttributes;
         MetaData = metaData;

--- a/eppo-sdk-test/helpers/AssignmentLogDataTest.cs
+++ b/eppo-sdk-test/helpers/AssignmentLogDataTest.cs
@@ -4,10 +4,12 @@ namespace eppo_sdk_test.helpers;
 
 public class AssignmentLogDataTest
 {
-    [Test]
-    public void ShouldBuildExperimentKey()
+    private AssignmentLogData assignmentLogData;
+
+    [SetUp]
+    public void Setup()
     {
-        var assignmentLogData = new AssignmentLogData(
+        assignmentLogData = new AssignmentLogData(
             "feature-flag",
             "allocation",
             "variation",
@@ -15,6 +17,17 @@ public class AssignmentLogDataTest
             new Subject(),
             new Dictionary<string, string>(),
             new Dictionary<string, string>());
+    }
+
+    [Test]
+    public void ShouldBuildExperimentKey()
+    {
         Assert.That(assignmentLogData.Experiment, Is.EqualTo("feature-flag-allocation"));
+    }
+
+    [Test]
+    public void ShouldSetAssignmentTimestamp()
+    {
+        Assert.That(assignmentLogData.Timestamp, Is.EqualTo(DateTime.UtcNow).Within(1).Milliseconds);
     }
 }

--- a/eppo-sdk-test/helpers/AssignmentLogDataTest.cs
+++ b/eppo-sdk-test/helpers/AssignmentLogDataTest.cs
@@ -28,6 +28,6 @@ public class AssignmentLogDataTest
     [Test]
     public void ShouldSetAssignmentTimestamp()
     {
-        Assert.That(assignmentLogData.Timestamp, Is.EqualTo(DateTime.UtcNow).Within(1).Milliseconds);
+        Assert.That(assignmentLogData.Timestamp, Is.EqualTo(DateTime.UtcNow).Within(100).Milliseconds);
     }
 }


### PR DESCRIPTION
🎟️ fixes ff-3389

`new DateTime()` sets the instance to January 1, 0001 at 00:00:00.000
`DateTime.UtcNow` sets the instance to the current date and time in UTC

Also, added a test to confirm

