### PR TITLE
feat: allow objects for Categorical Attributes

### DIFF
--- a/dot-net-sdk/dto/bandit/ContextAttributes.cs
+++ b/dot-net-sdk/dto/bandit/ContextAttributes.cs
@@ -35,7 +35,9 @@ public class ContextAttributes : IContextAttributes
         return obj;
     }
 
-    public static ContextAttributes FromNullableAttributes(string key, IDictionary<string, object?>? categoricalAttributes, IDictionary<string, object?>? numericAttributes)
+    public static ContextAttributes FromNullableAttributes(string key,
+                                                           IDictionary<string, object?>? categoricalAttributes,
+                                                           IDictionary<string, object?>? numericAttributes)
     {
         var obj = new ContextAttributes(key);
 
@@ -48,7 +50,9 @@ public class ContextAttributes : IContextAttributes
         return obj;
     }
 
-    public static ContextAttributes FromNullableAttributes(string key, IDictionary<string, string?>? categoricalAttributes, IDictionary<string, object?>? numericAttributes)
+    public static ContextAttributes FromNullableAttributes(string key,
+                                                           IDictionary<string, string?>? categoricalAttributes,
+                                                           IDictionary<string, object?>? numericAttributes)
     {
         var obj = new ContextAttributes(key);
         obj.AddDict(categoricalAttributes);

--- a/dot-net-sdk/dto/bandit/ContextAttributes.cs
+++ b/dot-net-sdk/dto/bandit/ContextAttributes.cs
@@ -35,6 +35,19 @@ public class ContextAttributes : IContextAttributes
         return obj;
     }
 
+    public static ContextAttributes FromNullableAttributes(string key, IDictionary<string, object?>? categoricalAttributes, IDictionary<string, object?>? numericAttributes)
+    {
+        var obj = new ContextAttributes(key);
+
+        if (categoricalAttributes != null)
+        {
+            // Attributes are sorted by type when added so we explcitly stringify values here.
+            obj.AddDict(categoricalAttributes.ToDictionary(k => k.Key, k => k.Value != null ? Compare.ToString(k.Value) : null));
+        }
+        obj.AddDict(NumbersOnly(numericAttributes));
+        return obj;
+    }
+
     public static ContextAttributes FromNullableAttributes(string key, IDictionary<string, string?>? categoricalAttributes, IDictionary<string, object?>? numericAttributes)
     {
         var obj = new ContextAttributes(key);

--- a/dot-net-sdk/eppo-sdk.csproj
+++ b/dot-net-sdk/eppo-sdk.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/Eppo-exp/dot-net-server-sdk</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Eppo-exp/dot-net-server-sdk</RepositoryUrl>
     <PackageId>Eppo.Sdk</PackageId>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <Company>Eppo Data</Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/eppo-sdk-test/BanditClientTest.cs
+++ b/eppo-sdk-test/BanditClientTest.cs
@@ -351,12 +351,12 @@ public class BanditClientTest
                     atr => atr.ActionKey,
                     atr => ContextAttributes.FromNullableAttributes(atr.ActionKey, atr.CategoricalAttributes, atr.NumericAttributes));
 
+            var subjectContext = ContextAttributes.FromNullableAttributes(subject.SubjectKey, subject.SubjectAttributes.CategoricalAttributes, subject.SubjectAttributes.NumericAttributes);
 
             var result = client.GetBanditAction(
                 banditTestCase.Flag,
-                subject.SubjectKey,
-                subject.SubjectAttributes.AsDict(),
-                subject.Actions.ToDictionary(atr => atr.ActionKey, atr => atr.AsDict()),
+                subjectContext,
+                actions,
                 banditTestCase.DefaultValue
             );
             Multiple(() =>
@@ -403,7 +403,7 @@ public record BanditSubjectTestRecord(string SubjectKey,
 }
 
 public record ActionTestRecord(string ActionKey,
-                               Dictionary<string, string?> CategoricalAttributes,
+                               Dictionary<string, object?> CategoricalAttributes,
                                Dictionary<string, object?> NumericAttributes)
 {
     public IDictionary<string, object?> AsDict()
@@ -426,7 +426,7 @@ public record ActionTestRecord(string ActionKey,
 public record SubjectAttributeSet
 {
     public IDictionary<string, object?>? NumericAttributes = new Dictionary<string, object?>();
-    public IDictionary<string, string?>? CategoricalAttributes = new Dictionary<string, string?>();
+    public IDictionary<string, object?>? CategoricalAttributes = new Dictionary<string, object?>();
 
     public IDictionary<string, object?> AsDict()
     {

--- a/eppo-sdk-test/dto/ContextAttributesTest.cs
+++ b/eppo-sdk-test/dto/ContextAttributesTest.cs
@@ -33,6 +33,36 @@ public class ContextAttributesTest
             Assert.That(actual.GetCategorical(), Is.EquivalentTo(expectedStrings));
         });
     }
+    [Test]
+    public void ShouldAllowExplicitCategoricalAttributes()
+    {
+        var categoryAttrs = new Dictionary<string, object?>() {
+            {"age", 30},
+            {"tier", "4"},
+            {"referralUser", true},
+            {"favouriteColour", "green"}
+        };
+        var numericAttrs = new Dictionary<string, object?>() {
+            {"accountAge", 0.5},
+        };
+        var expectedNumeric = new Dictionary<string, double>()
+        {
+            {"accountAge", 0.5},
+        };
+        var expectedStrings = new Dictionary<string, string>()
+        {
+            {"age","30"},
+            {"tier", "4"},
+            {"referralUser","true"},
+            {"favouriteColour","green"}
+        };
+        var actual = ContextAttributes.FromNullableAttributes("context", categoryAttrs, numericAttrs);
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual.GetNumeric(), Is.EquivalentTo(expectedNumeric));
+            Assert.That(actual.GetCategorical(), Is.EquivalentTo(expectedStrings));
+        });
+    }
 
     [Test]
     public void Add_InvalidType_ThrowsInvalidAttributeTypeException()


### PR DESCRIPTION
fixes ff-3548
## Motivation and Context
It is typical for the Eppo SDKs to allow subject and action attributes to be either automatically sorted into Categorical and Numerical by value type, or be flexible on type but explicit on Categorical/Numeric, relying on the SDK to cast values as needed

## Changes
- Add overload to `ContextAttributes.FromNullableAttributes` to allow passing `object?` as a Categorical attribute and converting to string using the "convention of conversion" established elsewhere in the SDK (i.e. boolean true converts to "true", which is different than .NET's `Boolean.ToString` which would produce "True"

## Tests
- Unit test for the specifics
- Updated the universal test parsing to exercise the new method.
Note: The unit testing was getting around this by coercing to string via reflection at the JSON parsing level.