### PR TITLE
chore: move api to baseUrl

### DIFF
--- a/dot-net-sdk/constants/Constants.cs
+++ b/dot-net-sdk/constants/Constants.cs
@@ -2,7 +2,7 @@ namespace eppo_sdk.constants;
 
 public class Constants
 {
-    public const string DEFAULT_BASE_URL = "https://fscdn.eppo.cloud";
+    public const string DEFAULT_BASE_URL = "https://fscdn.eppo.cloud/api";
 
     public const int REQUEST_TIMEOUT_MILLIS = 1000;
 
@@ -14,7 +14,7 @@ public class Constants
 
     public const int MAX_CACHE_ENTRIES = 1000;
 
-    public const string UFC_ENDPOINT = "/api/flag-config/v1/config";
+    public const string UFC_ENDPOINT = "/flag-config/v1/config";
 
-    public const string BANDIT_ENDPOINT = "/api/flag-config/v1/bandits";
+    public const string BANDIT_ENDPOINT = "/flag-config/v1/bandits";
 }

--- a/dot-net-sdk/eppo-sdk.csproj
+++ b/dot-net-sdk/eppo-sdk.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/Eppo-exp/dot-net-server-sdk</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Eppo-exp/dot-net-server-sdk</RepositoryUrl>
     <PackageId>Eppo.Sdk</PackageId>
-    <Version>3.4.0</Version>
+    <Version>3.4.2</Version>
     <Company>Eppo Data</Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/dot-net-sdk/eppo-sdk.csproj
+++ b/dot-net-sdk/eppo-sdk.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/Eppo-exp/dot-net-server-sdk</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Eppo-exp/dot-net-server-sdk</RepositoryUrl>
     <PackageId>Eppo.Sdk</PackageId>
-    <Version>3.4.2</Version>
+    <Version>3.5.1</Version>
     <Company>Eppo Data</Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/eppo-sdk-test/EppoClientTest.cs
+++ b/eppo-sdk-test/EppoClientTest.cs
@@ -57,7 +57,7 @@ public class EppoClientTest
         _mockServer = WireMockServer.Start();
         var response = GetMockFlagConfig();
         this._mockServer
-            .Given(Request.Create().UsingGet().WithPath(new RegexMatcher("api/flag-config/v1/config")))
+            .Given(Request.Create().UsingGet().WithPath(new RegexMatcher("flag-config/v1/config")))
             .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.OK).WithBody(response).WithHeader("Content-Type", "application/json"));
     }
 
@@ -153,7 +153,7 @@ public class EppoClientTest
             _mockServer!.Should()
                 .HaveReceivedACall()
                 .UsingGet()
-                .And.AtUrl($"{baseUrl}/api/flag-config/v1/config?apiKey=mock-api-key&sdkName=dotnet-client&sdkVersion={sdkVersion}");
+                .And.AtUrl($"{baseUrl}/flag-config/v1/config?apiKey=mock-api-key&sdkName=dotnet-client&sdkVersion={sdkVersion}");
 
             // Assert - Result verification
             That(result, Is.EqualTo(3));
@@ -256,7 +256,7 @@ public class EppoClientTest
         _mockServer!.Should()
             .HaveReceived(callCount).Calls()
             .UsingGet()
-            .And.AtUrl($"{baseUrl}/api/flag-config/v1/config?apiKey=mock-api-key&sdkName={sdkName}&sdkVersion={sdkVersion}");
+            .And.AtUrl($"{baseUrl}/flag-config/v1/config?apiKey=mock-api-key&sdkName={sdkName}&sdkVersion={sdkVersion}");
     }
 
     static List<AssignmentTestCase> GetTestAssignmentData()

--- a/eppo-sdk-test/http/HttpClientTest.cs
+++ b/eppo-sdk-test/http/HttpClientTest.cs
@@ -45,7 +45,7 @@ public class HttpClientTest
         var currentETag = "CURRENT";
 
         MockServer
-            .Given(Request.Create().UsingGet().WithPath(new RegexMatcher("api/flag-config/v1/config")))
+            .Given(Request.Create().UsingGet().WithPath(new RegexMatcher("flag-config/v1/config")))
             .RespondWith(Response.Create()
                 .WithStatusCode(HttpStatusCode.OK)
                 .WithBody(response)
@@ -99,7 +99,7 @@ public class HttpClientTest
         MockServer.Should()
             .HaveReceivedACall()
             .UsingGet()
-            .And.AtUrl($"{BaseUrl}/api/flag-config/v1/config?apiKey=none&sdkName=dotnetTest&sdkVersion=9.9.9");
+            .And.AtUrl($"{BaseUrl}/flag-config/v1/config?apiKey=none&sdkName=dotnetTest&sdkVersion=9.9.9");
     }
 
     [Test]


### PR DESCRIPTION
towards FF-3558
🎟️ [FF-3558](https://linear.app/eppo/issue/FF-3558/unify-sdk-request-baseurl)

## Motivation and Context
Most, nearly all in fact, of the SDKs use a baseUrl of https://fscdn.eppo.cloud/api and endpoint constants of `/flag-config/v1/config` and `/flag-config/v1/bandits` for flag and bandit requests.

All of the SDKs need to follow the common convention in order for our cross-SDK testing tools (scenario testing, benchmarking) to work seamlessly.

