### PR TITLE
[FFL-94] Expose Configuration and Client Readiness

### DIFF
--- a/dot-net-sdk/http/ConfigurationRequester.cs
+++ b/dot-net-sdk/http/ConfigurationRequester.cs
@@ -11,6 +11,7 @@ public interface IConfigurationRequester
     bool TryGetBandit(string key, out Bandit? bandit);
     bool TryGetFlag(string key, out Flag? flag);
     public BanditReferences GetBanditReferences();
+    Configuration GetConfiguration();
 }
 
 public class ConfigurationRequester : IConfigurationRequester
@@ -31,6 +32,8 @@ public class ConfigurationRequester : IConfigurationRequester
     public bool TryGetBandit(string key, out Bandit? bandit) => configurationStore.TryGetBandit(key, out bandit);
 
     public bool TryGetFlag(string key, out Flag? flag) => configurationStore.TryGetFlag(key, out flag);
+
+    public Configuration GetConfiguration() => configurationStore.GetConfiguration();
 
     public BanditReferences GetBanditReferences()
     {

--- a/dot-net-sdk/http/EppoHttpClient.cs
+++ b/dot-net-sdk/http/EppoHttpClient.cs
@@ -6,9 +6,8 @@ using RestSharp.Serializers.NewtonsoftJson;
 
 namespace eppo_sdk.http;
 
-
 /// <summary>
-/// Wraps the structured response from the API server with version information. 
+/// Wraps the structured response from the API server with version information.
 /// </summary>
 /// <typeparam name="TResource"></typeparam>
 public class VersionedResourceResponse<TResource>
@@ -17,9 +16,11 @@ public class VersionedResourceResponse<TResource>
     public readonly bool IsModified;
     public readonly string? VersionIdentifier;
 
-    public VersionedResourceResponse(TResource? resource,
-                                     string? versionIdentifier = null,
-                                     bool isModified = true)
+    public VersionedResourceResponse(
+        TResource? resource,
+        string? versionIdentifier = null,
+        bool isModified = true
+    )
     {
         Resource = resource;
         IsModified = isModified;
@@ -29,16 +30,16 @@ public class VersionedResourceResponse<TResource>
 
 /// <summary>
 /// The `EppoHttpClient` wraps the network call and response parsing, returning structured data to the caller.
-/// 
+///
 /// Resources returned are _versioned_, using mechanisms in the underlying transport layer to identify distinct
 /// versions of the resource and identify when it has not changed on the server. Specifically, the client makes
 /// use of the `ETAG` response header and the `IF-NONE-MATCH` request header to version the resource and
 /// determine if it has changed. When the resource has not changed, the network layer drops the response body
 /// from transport, saving bandwidth.
-/// 
+///
 /// Outwardly, the resource is wrapped in a `VersionedResourceResponse` instance carrying the version identifer
 /// and whether it changed. If callers do not pass their "current" version identifier, the resource is always
-/// loaded and `VersionedResourceResponse.IsModified` is `true`. 
+/// loaded and `VersionedResourceResponse.IsModified` is `true`.
 /// </summary>
 public class EppoHttpClient
 {
@@ -47,11 +48,13 @@ public class EppoHttpClient
     private readonly string _baseUrl;
     private readonly int _requestTimeoutMillis;
 
-    public EppoHttpClient(string apikey,
-                          string sdkName,
-                          string sdkVersion,
-                          string baseUrl,
-                          int requestTimeOutMillis = Constants.REQUEST_TIMEOUT_MILLIS)
+    public EppoHttpClient(
+        string apikey,
+        string sdkName,
+        string sdkVersion,
+        string baseUrl,
+        int requestTimeOutMillis = Constants.REQUEST_TIMEOUT_MILLIS
+    )
     {
         _defaultParams.Add("apiKey", apikey);
         _defaultParams.Add("sdkName", sdkName);
@@ -74,10 +77,17 @@ public class EppoHttpClient
     /// <param name="url"></param>
     /// <param name="lastVersion"></param> If provided, attempts to optimize network usage and response processing.
     /// <returns></returns>
-    public virtual VersionedResourceResponse<TResource> Get<TResource>(string url,
-                                                                       string? lastVersion = null)
+    public virtual VersionedResourceResponse<TResource> Get<TResource>(
+        string url,
+        string? lastVersion = null
+    )
     {
-        return Get<TResource>(url, new Dictionary<string, string>(), new Dictionary<string, string>(), lastVersion);
+        return Get<TResource>(
+            url,
+            new Dictionary<string, string>(),
+            new Dictionary<string, string>(),
+            lastVersion
+        );
     }
 
     /// <summary>
@@ -90,18 +100,20 @@ public class EppoHttpClient
     /// <param name="lastVersion"></param> If provided, attempts to optimize network usage and response processing.
     /// <returns></returns>
     /// <exception cref="UnauthorizedAccessException"></exception>
-    public VersionedResourceResponse<TResource> Get<TResource>(string url,
-                                                               Dictionary<string, string> parameters,
-                                                               Dictionary<string, string> headers,
-                                                               string? lastVersion = null)
+    public VersionedResourceResponse<TResource> Get<TResource>(
+        string url,
+        Dictionary<string, string> parameters,
+        Dictionary<string, string> headers,
+        string? lastVersion = null
+    )
     {
         // Prepare request.
         var request = new RestRequest
         {
-            Timeout = TimeSpan.FromMilliseconds(_requestTimeoutMillis)
+            Timeout = TimeSpan.FromMilliseconds(_requestTimeoutMillis),
         };
 
-        // Add query parameters.        
+        // Add query parameters.
         _defaultParams.ToList().ForEach(x => parameters.Add(x.Key, x.Value));
         parameters.ToList().ForEach(x => request.AddParameter(new QueryParameter(x.Key, x.Value)));
 
@@ -115,7 +127,10 @@ public class EppoHttpClient
         }
         request.AddHeaders(headers);
 
-        var client = new RestClient(_baseUrl + url, configureSerialization: s => s.UseNewtonsoftJson());
+        var client = new RestClient(
+            _baseUrl + url,
+            configureSerialization: s => s.UseNewtonsoftJson()
+        );
         var restResponse = client.Execute<TResource>(request);
 
         if (restResponse.StatusCode == HttpStatusCode.Unauthorized)
@@ -123,22 +138,29 @@ public class EppoHttpClient
             throw new UnauthorizedAccessException("Invalid Eppo API Key");
         }
 
-        if (restResponse.Data == null) {
+        if (restResponse.Data == null)
+        {
             // Useful to log why we have a null response body.
-        s_logger.Debug("Null response body, status was: " + restResponse.StatusCode);
+            s_logger.Debug("Null response body, status was: " + restResponse.StatusCode);
         }
 
         // HTTP uses the `ETag` header to identify the version of the resource (or entity) returned in the response.
         string? eTag;
         try
         {
-            eTag = restResponse.Headers?.ToList()?.Find(x => x.Name == "ETag").Value?.ToString() ?? null;
+            eTag =
+                restResponse.Headers?.ToList()?.Find(x => x.Name == "ETag").Value?.ToString()
+                ?? null;
         }
         catch (Exception)
         {
             eTag = null;
         }
 
-        return new VersionedResourceResponse<TResource>(restResponse.Data, eTag, isModified: restResponse.StatusCode != HttpStatusCode.NotModified);
+        return new VersionedResourceResponse<TResource>(
+            restResponse.Data,
+            eTag,
+            isModified: restResponse.StatusCode != HttpStatusCode.NotModified
+        );
     }
 }

--- a/dot-net-sdk/store/Configuration.cs
+++ b/dot-net-sdk/store/Configuration.cs
@@ -1,0 +1,160 @@
+using System.Collections.Immutable;
+using eppo_sdk.dto;
+using eppo_sdk.dto.bandit;
+
+namespace eppo_sdk.store;
+
+/// <summary>
+/// Immutable configuration snapshot containing flags, bandits, and metadata.
+/// Provides thread-safe read-only access to configuration data.
+/// </summary>
+public sealed class Configuration
+{
+    private readonly ImmutableDictionary<string, Flag> _flags;
+    private readonly ImmutableDictionary<string, Bandit> _bandits;
+    private readonly ImmutableDictionary<string, object> _metadata;
+
+    // Metadata key constants
+    private const string KEY_BANDIT_REFERENCES = "banditReferences";
+    private const string KEY_BANDIT_VERSIONS = "banditVersions";
+    private const string KEY_FLAG_CONFIG_VERSION = "ufcVersion";
+
+    /// <summary>
+    /// Initializes a new instance of the Configuration class.
+    /// </summary>
+    /// <param name="flags">The flags to include in this configuration.</param>
+    /// <param name="bandits">The bandits to include in this configuration.</param>
+    /// <param name="metadata">The metadata to include in this configuration.</param>
+    public Configuration(
+        IEnumerable<Flag> flags,
+        IEnumerable<Bandit> bandits,
+        IDictionary<string, object> metadata
+    )
+    {
+        _flags = flags.ToImmutableDictionary(f => f.Key, f => f);
+        _bandits = bandits.ToImmutableDictionary(b => b.BanditKey, b => b);
+        _metadata = metadata.ToImmutableDictionary();
+    }
+
+    /// <summary>
+    /// Attempts to retrieve a flag by its key.
+    /// </summary>
+    /// <param name="key">The flag key to look up.</param>
+    /// <param name="flag">When this method returns, contains the flag associated with the specified key, if found; otherwise, null.</param>
+    /// <returns>true if the flag was found; otherwise, false.</returns>
+    public bool TryGetFlag(string key, out Flag? flag)
+    {
+        return _flags.TryGetValue(key, out flag);
+    }
+
+    /// <summary>
+    /// Attempts to retrieve a bandit by its key.
+    /// </summary>
+    /// <param name="key">The bandit key to look up.</param>
+    /// <param name="bandit">When this method returns, contains the bandit associated with the specified key, if found; otherwise, null.</param>
+    /// <returns>true if the bandit was found; otherwise, false.</returns>
+    public bool TryGetBandit(string key, out Bandit? bandit)
+    {
+        return _bandits.TryGetValue(key, out bandit);
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the bandit references metadata.
+    /// </summary>
+    /// <param name="banditReferences">When this method returns, contains the bandit references if found; otherwise, null.</param>
+    /// <returns>true if bandit references were found; otherwise, false.</returns>
+    public bool TryGetBanditReferences(out BanditReferences? banditReferences)
+    {
+        return TryGetMetadata(KEY_BANDIT_REFERENCES, out banditReferences);
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the bandit versions metadata.
+    /// </summary>
+    /// <param name="banditVersions">When this method returns, contains the bandit versions if found; otherwise, null.</param>
+    /// <returns>true if bandit versions were found; otherwise, false.</returns>
+    public bool TryGetBanditVersions(out IEnumerable<string>? banditVersions)
+    {
+        return TryGetMetadata(KEY_BANDIT_VERSIONS, out banditVersions);
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the flag configuration version metadata.
+    /// </summary>
+    /// <param name="flagConfigVersion">When this method returns, contains the flag configuration version if found; otherwise, null.</param>
+    /// <returns>true if flag configuration version was found; otherwise, false.</returns>
+    public bool TryGetFlagConfigVersion(out string? flagConfigVersion)
+    {
+        return TryGetMetadata(KEY_FLAG_CONFIG_VERSION, out flagConfigVersion);
+    }
+
+    /// <summary>
+    /// Gets the bandit references metadata, or null if not found.
+    /// </summary>
+    public BanditReferences? BanditReferences
+    {
+        get
+        {
+            TryGetBanditReferences(out var banditReferences);
+            return banditReferences;
+        }
+    }
+
+    /// <summary>
+    /// Gets the bandit versions metadata, or an empty collection if not found.
+    /// </summary>
+    public IEnumerable<string> BanditVersions
+    {
+        get
+        {
+            TryGetBanditVersions(out var banditVersions);
+            return banditVersions ?? Array.Empty<string>();
+        }
+    }
+
+    /// <summary>
+    /// Gets the flag configuration version metadata, or null if not found.
+    /// </summary>
+    public string? FlagConfigVersion
+    {
+        get
+        {
+            TryGetFlagConfigVersion(out var flagConfigVersion);
+            return flagConfigVersion;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to retrieve metadata by its key.
+    /// </summary>
+    /// <typeparam name="TMetadata">The type of the metadata value.</typeparam>
+    /// <param name="key">The metadata key to look up.</param>
+    /// <param name="metadata">When this method returns, contains the metadata associated with the specified key, if found; otherwise, default value.</param>
+    /// <returns>true if the metadata was found; otherwise, false.</returns>
+    public bool TryGetMetadata<TMetadata>(string key, out TMetadata? metadata)
+    {
+        if (_metadata.TryGetValue(key, out var value) && value is TMetadata typedValue)
+        {
+            metadata = typedValue;
+            return true;
+        }
+
+        metadata = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Gets all flags in this configuration.
+    /// </summary>
+    public IEnumerable<Flag> Flags => _flags.Values;
+
+    /// <summary>
+    /// Gets all bandits in this configuration.
+    /// </summary>
+    public IEnumerable<Bandit> Bandits => _bandits.Values;
+
+    /// <summary>
+    /// Gets all metadata in this configuration.
+    /// </summary>
+    public IDictionary<string, object> Metadata => _metadata;
+}

--- a/dot-net-sdk/store/ConfigurationStore.cs
+++ b/dot-net-sdk/store/ConfigurationStore.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using eppo_sdk.dto;
 using eppo_sdk.dto.bandit;
 using Microsoft.Extensions.Caching.Memory;
@@ -10,20 +11,83 @@ public class ConfigurationStore : IConfigurationStore
     private readonly MemoryCache metadataCache;
     private readonly MemoryCache banditCache;
 
-    private readonly MemoryCacheEntryOptions cacheOptions = new MemoryCacheEntryOptions().SetSize(1);
+    private readonly MemoryCacheEntryOptions cacheOptions = new MemoryCacheEntryOptions().SetSize(
+        1
+    );
 
     /// <summary>
     /// Used for concurrent-read and exclusive-write locking.
     /// </summary>
     private readonly ReaderWriterLockSlim cacheLock = new();
 
-    public ConfigurationStore(MemoryCache flagConfigurationCache,
-                              MemoryCache banditModelCache,
-                              MemoryCache metadataCache)
+    public ConfigurationStore(
+        MemoryCache flagConfigurationCache,
+        MemoryCache banditModelCache,
+        MemoryCache metadataCache
+    )
     {
         this.ufcCache = flagConfigurationCache;
         this.banditCache = banditModelCache;
         this.metadataCache = metadataCache;
+    }
+
+    public Configuration GetConfiguration()
+    {
+        cacheLock.EnterReadLock();
+        try
+        {
+            var flags = ExtractFromCache<Flag>(ufcCache);
+            var bandits = ExtractFromCache<Bandit>(banditCache);
+            var metadata = ExtractFromCache<object>(metadataCache);
+
+            return new Configuration(flags.Values, bandits.Values, metadata);
+        }
+        finally
+        {
+            cacheLock.ExitReadLock();
+        }
+    }
+
+    /// <summary>
+    /// Extracts all entries from a MemoryCache using reflection.
+    /// This is necessary because MemoryCache doesn't provide enumeration capabilities.
+    /// </summary>
+    private static Dictionary<string, T> ExtractFromCache<T>(MemoryCache cache)
+    {
+        var result = new Dictionary<string, T>();
+
+        try
+        {
+            // Use reflection to access the private _store field
+            var field = typeof(MemoryCache).GetField(
+                "_store",
+                BindingFlags.NonPublic | BindingFlags.Instance
+            );
+            if (field?.GetValue(cache) is IDictionary<object, object> store)
+            {
+                foreach (var entry in store.Values)
+                {
+                    // Access the Key and Value properties of each cache entry
+                    var keyProperty = entry.GetType().GetProperty("Key");
+                    var valueProperty = entry.GetType().GetProperty("Value");
+
+                    if (
+                        keyProperty?.GetValue(entry) is string key
+                        && valueProperty?.GetValue(entry) is T value
+                    )
+                    {
+                        result[key] = value;
+                    }
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // If reflection fails, return empty dictionary
+            // This ensures the system remains stable even if internal implementation changes
+        }
+
+        return result;
     }
 
     public void SetConfiguration(IEnumerable<Flag> flags, IDictionary<string, object> metadata)
@@ -40,7 +104,11 @@ public class ConfigurationStore : IConfigurationStore
         }
     }
 
-    public void SetConfiguration(IEnumerable<Flag> flags, IEnumerable<Bandit> bandits, IDictionary<string, object> metadata)
+    public void SetConfiguration(
+        IEnumerable<Flag> flags,
+        IEnumerable<Bandit> bandits,
+        IDictionary<string, object> metadata
+    )
     {
         cacheLock.EnterWriteLock();
         try

--- a/dot-net-sdk/store/IConfigurationStore.cs
+++ b/dot-net-sdk/store/IConfigurationStore.cs
@@ -14,7 +14,11 @@ public interface IConfigurationStore
     /// <param name="banditFlagReferences"></param>
     /// <param name="bandits">Bandit models to set. If null, existing bandits are not overwritten.</param>
     /// <param name="metadata"></param>
-    void SetConfiguration(IEnumerable<Flag> flags, IEnumerable<Bandit> bandits, IDictionary<string, object> metadata);
+    void SetConfiguration(
+        IEnumerable<Flag> flags,
+        IEnumerable<Bandit> bandits,
+        IDictionary<string, object> metadata
+    );
 
     /// <summary>
     /// Sets just the UFC configuration values (flags and metadata), **without updating `bandits`**, in one idempotent method.
@@ -24,6 +28,13 @@ public interface IConfigurationStore
     /// <param name="bandits">Bandit models to set. If null, existing bandits are not overwritten.</param>
     /// <param name="metadata"></param>
     void SetConfiguration(IEnumerable<Flag> flags, IDictionary<string, object> metadata);
+
+    /// <summary>
+    /// Gets the current configuration snapshot containing all flags, bandits, and metadata.
+    /// </summary>
+    /// <returns>A Configuration object representing the current state.</returns>
+    Configuration GetConfiguration();
+
     bool TryGetBandit(string key, out Bandit? bandit);
     bool TryGetFlag(string key, out Flag? flag);
     bool TryGetMetadata<MType>(string key, out MType? metadata);

--- a/eppo-sdk-test/store/ConfigurationTest.cs
+++ b/eppo-sdk-test/store/ConfigurationTest.cs
@@ -1,0 +1,216 @@
+using eppo_sdk.dto;
+using eppo_sdk.dto.bandit;
+using eppo_sdk.store;
+using static NUnit.Framework.Assert;
+
+namespace eppo_sdk_test.store;
+
+public class ConfigurationTest
+{
+    private Configuration _configuration;
+    private Flag _testFlag;
+    private Bandit _testBandit;
+    private Dictionary<string, object> _testMetadata;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _testFlag = new Flag(
+            Key: "test-flag",
+            Enabled: true,
+            Allocations: new List<Allocation>(),
+            VariationType: EppoValueType.STRING,
+            Variations: new Dictionary<string, Variation>(),
+            TotalShards: 10000
+        );
+
+        _testBandit = new Bandit(
+            BanditKey: "test-bandit",
+            ModelName: "test-model",
+            UpdatedAt: DateTime.UtcNow,
+            ModelVersion: "v1.0",
+            ModelData: new ModelData
+            {
+                Gamma = 1.0,
+                DefaultActionScore = 0.0,
+                ActionProbabilityFloor = 0.0,
+                Coefficients = new Dictionary<string, ActionCoefficients>()
+            }
+        );
+
+        var banditReferences = new BanditReferences();
+        banditReferences["test-bandit"] = new BanditReference(
+            ModelVersion: "v1.0",
+            FlagVariations: new[]
+            {
+                new BanditFlagVariation(
+                    Key: "test-bandit",
+                    FlagKey: "test-flag", 
+                    AllocationKey: "allocation1",
+                    VariationKey: "variation1",
+                    VariationValue: "variation1"
+                )
+            }
+        );
+
+        _testMetadata = new Dictionary<string, object>
+        {
+            ["banditReferences"] = banditReferences,
+            ["banditVersions"] = new List<string> { "v1.0", "v1.1" },
+            ["ufcVersion"] = "1.0.0",
+            ["customKey"] = "customValue"
+        };
+
+        _configuration = new Configuration(
+            new[] { _testFlag },
+            new[] { _testBandit },
+            _testMetadata
+        );
+    }
+
+    [Test]
+    public void ShouldRetrieveFlag()
+    {
+        Multiple(() =>
+        {
+            That(_configuration.TryGetFlag("test-flag", out Flag? flag), Is.True);
+            That(flag, Is.Not.Null);
+            That(flag!.Key, Is.EqualTo("test-flag"));
+        });
+    }
+
+    [Test]
+    public void ShouldReturnFalseForNonExistentFlag()
+    {
+        Multiple(() =>
+        {
+            That(_configuration.TryGetFlag("non-existent", out Flag? flag), Is.False);
+            That(flag, Is.Null);
+        });
+    }
+
+    [Test]
+    public void ShouldRetrieveBandit()
+    {
+        Multiple(() =>
+        {
+            That(_configuration.TryGetBandit("test-bandit", out Bandit? bandit), Is.True);
+            That(bandit, Is.Not.Null);
+            That(bandit!.BanditKey, Is.EqualTo("test-bandit"));
+        });
+    }
+
+    [Test]
+    public void ShouldReturnFalseForNonExistentBandit()
+    {
+        Multiple(() =>
+        {
+            That(_configuration.TryGetBandit("non-existent", out Bandit? bandit), Is.False);
+            That(bandit, Is.Null);
+        });
+    }
+
+    [Test]
+    public void ShouldRetrieveBanditReferences()
+    {
+        Multiple(() =>
+        {
+            That(_configuration.TryGetBanditReferences(out BanditReferences? banditReferences), Is.True);
+            That(banditReferences, Is.Not.Null);
+            That(_configuration.BanditReferences, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void ShouldRetrieveBanditVersions()
+    {
+        Multiple(() =>
+        {
+            That(_configuration.TryGetBanditVersions(out IEnumerable<string>? banditVersions), Is.True);
+            That(banditVersions, Is.Not.Null);
+            That(banditVersions!.Count(), Is.EqualTo(2));
+            That(_configuration.BanditVersions.Count(), Is.EqualTo(2));
+            That(_configuration.BanditVersions.Contains("v1.0"), Is.True);
+            That(_configuration.BanditVersions.Contains("v1.1"), Is.True);
+        });
+    }
+
+    [Test]
+    public void ShouldRetrieveFlagConfigVersion()
+    {
+        Multiple(() =>
+        {
+            That(_configuration.TryGetFlagConfigVersion(out string? flagConfigVersion), Is.True);
+            That(flagConfigVersion, Is.EqualTo("1.0.0"));
+            That(_configuration.FlagConfigVersion, Is.EqualTo("1.0.0"));
+        });
+    }
+
+    [Test]
+    public void ShouldRetrieveMetadata()
+    {
+        Multiple(() =>
+        {
+            That(_configuration.TryGetMetadata<string>("customKey", out string? metadata), Is.True);
+            That(metadata, Is.EqualTo("customValue"));
+        });
+    }
+
+    [Test]
+    public void ShouldReturnFalseForNonExistentMetadata()
+    {
+        Multiple(() =>
+        {
+            That(_configuration.TryGetMetadata<string>("non-existent", out string? metadata), Is.False);
+            That(metadata, Is.Null);
+        });
+    }
+
+    [Test]
+    public void ShouldReturnFalseForWrongMetadataType()
+    {
+        Multiple(() =>
+        {
+            That(_configuration.TryGetMetadata<int>("ufcVersion", out int metadata), Is.False);
+            That(metadata, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void ShouldProvideImmutableCollections()
+    {
+        Multiple(() =>
+        {
+            That(_configuration.Flags.Count(), Is.EqualTo(1));
+            That(_configuration.Flags.First().Key, Is.EqualTo("test-flag"));
+
+            That(_configuration.Bandits.Count(), Is.EqualTo(1));
+            That(_configuration.Bandits.First().BanditKey, Is.EqualTo("test-bandit"));
+
+            That(_configuration.Metadata, Has.Count.EqualTo(4));
+            That(_configuration.Metadata["ufcVersion"], Is.EqualTo("1.0.0"));
+        });
+    }
+
+    [Test]
+    public void ShouldHandleMissingSpecificMetadata()
+    {
+        var emptyConfiguration = new Configuration(
+            Array.Empty<Flag>(),
+            Array.Empty<Bandit>(),
+            new Dictionary<string, object>()
+        );
+
+        Multiple(() =>
+        {
+            That(emptyConfiguration.TryGetBanditReferences(out _), Is.False);
+            That(emptyConfiguration.BanditReferences, Is.Null);
+
+            That(emptyConfiguration.TryGetBanditVersions(out _), Is.False);
+            That(emptyConfiguration.BanditVersions, Is.Empty);
+
+            That(emptyConfiguration.TryGetFlagConfigVersion(out _), Is.False);
+            That(emptyConfiguration.FlagConfigVersion, Is.Null);
+        });
+    }
+} 


### PR DESCRIPTION
_Eppo Internal:_

:tickets: Fixes __issue__

## Motivation and Context
A customer is having issues with the .NET SDK not being initialized when assignments are requests (possibly multi-threaded induced race condition).

## Description
- Refactor configuration handling into a central Configuration object.
- New `IsConfigurationReady` and `WaitForConfiguration` methods on `EppoClietn`
- Expose `Configruation` via `EppoClient.GetConfiguration`

## How has this been documented?
n/a

## How has this been tested?
new unit tests
