### PR TITLE
fix: replace net7.0 with net9.0 for test project

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,8 +40,8 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-          7.0.x
           8.0.x
+          9.0.x
           10.0.x
 
     - name: Lint and format check
@@ -63,6 +63,6 @@ jobs:
 
     - name: Test all target frameworks
       run: |
-        dotnet test --framework net7.0 --verbosity normal
         dotnet test --framework net8.0 --verbosity normal
+        dotnet test --framework net9.0 --verbosity normal
         dotnet test --framework net10.0 --verbosity normal

--- a/eppo-sdk-test/eppo-sdk-test.csproj
+++ b/eppo-sdk-test/eppo-sdk-test.csproj
@@ -7,21 +7,9 @@
     <IsTestProject>true</IsTestProject>
     <OutputType>Library</OutputType>
     <LangVersion>14</LangVersion>
-    <TargetFrameworks>net7.0;net8.0;net10.0</TargetFrameworks>
-
-    <!-- default (net7.0-specific) versions -->
-    <MicrosoftNETTestSdkVersion>17.8.0</MicrosoftNETTestSdkVersion>
-    <NUnitAdapterVersion>4.5.0</NUnitAdapterVersion>
-
-    <!-- net8.0+ (including net10.0 and future versions) -->
-    <MicrosoftNETTestSdkVersion
-      Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))"
-      >18.0.1</MicrosoftNETTestSdkVersion
-    >
-    <NUnitAdapterVersion
-      Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))"
-      >6.0.1</NUnitAdapterVersion
-    >
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <MicrosoftNETTestSdkVersion>18.0.1</MicrosoftNETTestSdkVersion>
+    <NUnitAdapterVersion>6.0.1</NUnitAdapterVersion>
   </PropertyGroup>
   <!-- Common packages for all frameworks -->
   <ItemGroup>


### PR DESCRIPTION
.NET 7.0 is EOL and no longer available on GitHub runners. Replace with net9.0 for testing alongside net8.0 and net10.0.

_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

https://github.com/Eppo-exp/dot-net-server-sdk/actions/runs/20526950163/job/58971929913

## Description
[//]: # (Describe your changes in detail)

## How has this been documented?
[//]: # (Please describe how you documented the developer impact of your changes; link to PRs or issues or explain why no documentation changes are required)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

