### PR TITLE
fix: install .NET 7 runtime in release workflow for multi-target testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,15 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-
         uses: actions/checkout@v2
-      - name: Setup .NET
+        
+      - name: Setup .NET versions
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.x
+          dotnet-version: |
+            7.0.x
+            8.0.x
+            10.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/eppo-sdk-test/EppoClientTest.cs
+++ b/eppo-sdk-test/EppoClientTest.cs
@@ -108,13 +108,13 @@ public class EppoClientTest
         var config = new EppoClientConfig("mock-api-key", _mockAssignmentLogger.Object)
         {
             BaseUrl = _mockServer?.Urls[0]!,
-            PollingIntervalInMillis = 25,
+            PollingIntervalInMillis = 50,
             PollingJitterInMillis = 0,
         };
 
         _client = EppoClient.Init(config);
 
-        Thread.Sleep(30);
+        Thread.Sleep(75);
 
         VerifyApiCalls(2);
     }


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

We used to build and test in .NET 7, we should continue to test in that environment to ensure backwards compatibility.

## Description
[//]: # (Describe your changes in detail)

1. Runtime Issue
The net7.0 test still fails to start: `Framework: 'Microsoft.NETCore.App', version '7.0.0' (x64)`

Was missing because the release didn't have the same .NET environments setup as the test workflow

https://github.com/Eppo-exp/dot-net-server-sdk/blob/f4ea5d08b597b40664698d0422b386828e1d27d3/.github/workflows/run-tests.yml#L39-L45

This line https://github.com/Eppo-exp/dot-net-server-sdk/blob/d5ac1f83da7b9a5e6fdd765d726bdd378a78e83b/.github/workflows/release.yml#L33

Will try to run in all the environments specified here
https://github.com/Eppo-exp/dot-net-server-sdk/blob/f4ea5d08b597b40664698d0422b386828e1d27d3/eppo-sdk-test/eppo-sdk-test.csproj#L10

2. Test Failure
A test is failing in the net10.0 run:
`Expected 2 GET request(s) to http://localhost:45673/flag-config/v1/config?apiKey=mock-api-key&sdkName=dotnet-server&sdkVersion=4.2.0, but found 3`

Might be due to flakiness between the test environments between 7, 8, and 10.

## How has this been documented?
[//]: # (Please describe how you documented the developer impact of your changes; link to PRs or issues or explain why no documentation changes are required)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

