### PR TITLE
fix: replace Thread.Sleep with TimeProvider in flaky test

### DIFF
--- a/dot-net-sdk/EppoClient.cs
+++ b/dot-net-sdk/EppoClient.cs
@@ -272,7 +272,8 @@ public sealed class EppoClient : IDisposable
                 fetchExperimentsTask = new FetchExperimentsTask(
                     configRequester,
                     eppoClientConfig.PollingIntervalInMillis,
-                    eppoClientConfig.PollingJitterInMillis
+                    eppoClientConfig.PollingJitterInMillis,
+                    eppoClientConfig.TimeProvider
                 );
             }
 

--- a/dot-net-sdk/EppoClientConfig.cs
+++ b/dot-net-sdk/EppoClientConfig.cs
@@ -62,6 +62,8 @@ public class EppoClientConfig
         }
     }
 
+    internal TimeProvider? TimeProvider { get; set; }
+
     internal class DefaultLogger : IAssignmentLogger
     {
         public void LogAssignment(AssignmentLogData assignmentLogData)

--- a/dot-net-sdk/eppo-sdk.csproj
+++ b/dot-net-sdk/eppo-sdk.csproj
@@ -14,6 +14,11 @@
     <LangVersion>14</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>eppo-sdk-test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  <ItemGroup>
     <None Remove="exception\" />
     <None Remove="logger\" />
     <None Include="../README.md" Pack="true" PackagePath="\" />
@@ -27,6 +32,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NLog" Version="6.0.7" />
     <PackageReference Include="NuGet.Versioning" Version="7.0.1" />

--- a/dot-net-sdk/tasks/FetchExperimentsTask.cs
+++ b/dot-net-sdk/tasks/FetchExperimentsTask.cs
@@ -10,19 +10,22 @@ public class FetchExperimentsTask : IDisposable
     private readonly long TimeIntervalInMillis;
     private readonly long JitterTimeIntervalInMillis;
     private readonly IConfigurationRequester ConfigLoader;
-    private readonly Timer Timer;
+    private readonly ITimer Timer;
+    private readonly TimeProvider TimeProvider;
 
     public FetchExperimentsTask(
         IConfigurationRequester config,
         long timeIntervalInMillis,
-        long jitterTimeIntervalInMillis
+        long jitterTimeIntervalInMillis,
+        TimeProvider? timeProvider = null
     )
     {
         ConfigLoader = config;
         TimeIntervalInMillis = timeIntervalInMillis;
         JitterTimeIntervalInMillis = jitterTimeIntervalInMillis;
+        TimeProvider = timeProvider ?? TimeProvider.System;
 
-        Timer = new Timer(state => Run(), null, timeIntervalInMillis, Timeout.Infinite);
+        Timer = TimeProvider.CreateTimer(state => Run(), null, TimeSpan.FromMilliseconds(timeIntervalInMillis), Timeout.InfiniteTimeSpan);
     }
 
     internal void Run()
@@ -36,7 +39,7 @@ public class FetchExperimentsTask : IDisposable
 
         var nextTick = TimeIntervalInMillis - jitter;
 
-        Timer.Change(nextTick, Timeout.Infinite);
+        Timer.Change(TimeSpan.FromMilliseconds(nextTick), Timeout.InfiniteTimeSpan);
         try
         {
             ConfigLoader.FetchAndActivateConfiguration();

--- a/dot-net-sdk/tasks/FetchExperimentsTask.cs
+++ b/dot-net-sdk/tasks/FetchExperimentsTask.cs
@@ -25,7 +25,12 @@ public class FetchExperimentsTask : IDisposable
         JitterTimeIntervalInMillis = jitterTimeIntervalInMillis;
         TimeProvider = timeProvider ?? TimeProvider.System;
 
-        Timer = TimeProvider.CreateTimer(state => Run(), null, TimeSpan.FromMilliseconds(timeIntervalInMillis), Timeout.InfiniteTimeSpan);
+        Timer = TimeProvider.CreateTimer(
+            state => Run(),
+            null,
+            TimeSpan.FromMilliseconds(timeIntervalInMillis),
+            Timeout.InfiniteTimeSpan
+        );
     }
 
     internal void Run()

--- a/dot-net-sdk/tasks/FetchExperimentsTask.cs
+++ b/dot-net-sdk/tasks/FetchExperimentsTask.cs
@@ -17,9 +17,8 @@ public class FetchExperimentsTask : IDisposable
         IConfigurationRequester config,
         long timeIntervalInMillis,
         long jitterTimeIntervalInMillis
-    ) : this(config, timeIntervalInMillis, jitterTimeIntervalInMillis, null)
-    {
-    }
+    )
+        : this(config, timeIntervalInMillis, jitterTimeIntervalInMillis, null) { }
 
     internal FetchExperimentsTask(
         IConfigurationRequester config,

--- a/dot-net-sdk/tasks/FetchExperimentsTask.cs
+++ b/dot-net-sdk/tasks/FetchExperimentsTask.cs
@@ -16,8 +16,16 @@ public class FetchExperimentsTask : IDisposable
     public FetchExperimentsTask(
         IConfigurationRequester config,
         long timeIntervalInMillis,
+        long jitterTimeIntervalInMillis
+    ) : this(config, timeIntervalInMillis, jitterTimeIntervalInMillis, null)
+    {
+    }
+
+    internal FetchExperimentsTask(
+        IConfigurationRequester config,
+        long timeIntervalInMillis,
         long jitterTimeIntervalInMillis,
-        TimeProvider? timeProvider = null
+        TimeProvider? timeProvider
     )
     {
         ConfigLoader = config;

--- a/eppo-sdk-test/EppoClientTest.cs
+++ b/eppo-sdk-test/EppoClientTest.cs
@@ -6,6 +6,7 @@ using eppo_sdk.dto;
 using eppo_sdk.helpers;
 using eppo_sdk.logger;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -105,16 +106,19 @@ public class EppoClientTest
     [Test]
     public void ShouldPollForConfigInServerMode()
     {
+        var fakeTimeProvider = new FakeTimeProvider();
         var config = new EppoClientConfig("mock-api-key", _mockAssignmentLogger.Object)
         {
             BaseUrl = _mockServer?.Urls[0]!,
             PollingIntervalInMillis = 50,
             PollingJitterInMillis = 0,
+            TimeProvider = fakeTimeProvider
         };
 
         _client = EppoClient.Init(config);
 
-        Thread.Sleep(75);
+        // Advance time to trigger the first poll after initialization
+        fakeTimeProvider.Advance(TimeSpan.FromMilliseconds(50));
 
         VerifyApiCalls(2);
     }

--- a/eppo-sdk-test/EppoClientTest.cs
+++ b/eppo-sdk-test/EppoClientTest.cs
@@ -112,7 +112,7 @@ public class EppoClientTest
             BaseUrl = _mockServer?.Urls[0]!,
             PollingIntervalInMillis = 50,
             PollingJitterInMillis = 0,
-            TimeProvider = fakeTimeProvider
+            TimeProvider = fakeTimeProvider,
         };
 
         _client = EppoClient.Init(config);

--- a/eppo-sdk-test/eppo-sdk-test.csproj
+++ b/eppo-sdk-test/eppo-sdk-test.csproj
@@ -26,10 +26,7 @@
   <!-- Common packages for all frameworks -->
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
-    <PackageReference Include="Meziantou.Polyfill" Version="1.0.71">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NUnit" Version="4.4.0" />

--- a/eppo-sdk-test/http/FetchExperimentsTaskTest.cs
+++ b/eppo-sdk-test/http/FetchExperimentsTaskTest.cs
@@ -27,7 +27,12 @@ public class FetchExperimentsTaskTest
             .Throws(new SystemException("Error loading"));
 
         var fakeTimeProvider = new FakeTimeProvider();
-        FetchExperimentsTask fet = new FetchExperimentsTask(mockConfig.Object, 250, 0, fakeTimeProvider);
+        FetchExperimentsTask fet = new FetchExperimentsTask(
+            mockConfig.Object,
+            250,
+            0,
+            fakeTimeProvider
+        );
 
         // Advance time to trigger 2+ fetch attempts.
         // If the FetchExperimentsTask encounters an uncaught exception, it will fail the test.

--- a/eppo-sdk-test/http/FetchExperimentsTaskTest.cs
+++ b/eppo-sdk-test/http/FetchExperimentsTaskTest.cs
@@ -6,6 +6,7 @@ using eppo_sdk.http;
 using eppo_sdk.store;
 using eppo_sdk.tasks;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using NUnit.Framework.Internal;
 
@@ -16,19 +17,27 @@ public class FetchExperimentsTaskTest
     [Test]
     public void ShouldFailGracefully()
     {
+        var callCount = 0;
         Mock<IConfigurationRequester> mockConfig = new Mock<IConfigurationRequester>();
 
         // Throw an exception when the config is loaded.
         mockConfig
             .Setup(mc => mc.FetchAndActivateConfiguration())
+            .Callback(() => callCount++)
             .Throws(new SystemException("Error loading"));
 
-        FetchExperimentsTask fet = new FetchExperimentsTask(mockConfig.Object, 250, 0);
+        var fakeTimeProvider = new FakeTimeProvider();
+        FetchExperimentsTask fet = new FetchExperimentsTask(mockConfig.Object, 250, 0, fakeTimeProvider);
 
-        // Sleep one second to await 2+ fetch attempts.
+        // Advance time to trigger 2+ fetch attempts.
         // If the FetchExperimentsTask encounters an uncaught exception, it will fail the test.
-        Thread.Sleep(1000);
+        fakeTimeProvider.Advance(TimeSpan.FromMilliseconds(250)); // First timer
+        fakeTimeProvider.Advance(TimeSpan.FromMilliseconds(250)); // Second timer
+        fakeTimeProvider.Advance(TimeSpan.FromMilliseconds(250)); // Third timer
 
         fet.Dispose();
+
+        // Verify that multiple fetch attempts were made despite exceptions
+        Assert.That(callCount, Is.GreaterThanOrEqualTo(2));
     }
 }

--- a/eppo-sdk-test/tasks/FetchExperimentsTaskTest.cs
+++ b/eppo-sdk-test/tasks/FetchExperimentsTaskTest.cs
@@ -23,11 +23,11 @@ public class FetchExperimentsTaskTest
         var fakeTimeProvider = new FakeTimeProvider();
         var task = new FetchExperimentsTask(mockConfig.Object, 200, 10, fakeTimeProvider);
 
-        // Advance time to trigger the first timer callback (200ms)
+        // Advance time to trigger the first timer callback: exactly 200ms (no jitter on initial delay)
         fakeTimeProvider.Advance(TimeSpan.FromMilliseconds(200));
 
-        // Advance time to trigger the second timer callback (accounting for 2.5x original interval)
-        fakeTimeProvider.Advance(TimeSpan.FromMilliseconds(300));
+        // Advance time to trigger the second timer callback: 191-199ms (with jitter), so 199ms covers worst case
+        fakeTimeProvider.Advance(TimeSpan.FromMilliseconds(199));
 
         // Verify at least 2 calls (initial call + at least one timer call)
         Assert.That(count, Is.GreaterThanOrEqualTo(2));

--- a/eppo-sdk-test/tasks/FetchExperimentsTaskTest.cs
+++ b/eppo-sdk-test/tasks/FetchExperimentsTaskTest.cs
@@ -25,7 +25,7 @@ public class FetchExperimentsTaskTest
 
         // Advance time to trigger the first timer callback (200ms)
         fakeTimeProvider.Advance(TimeSpan.FromMilliseconds(200));
-        
+
         // Advance time to trigger the second timer callback (accounting for 2.5x original interval)
         fakeTimeProvider.Advance(TimeSpan.FromMilliseconds(300));
 

--- a/eppo-sdk-test/tasks/FetchExperimentsTaskTest.cs
+++ b/eppo-sdk-test/tasks/FetchExperimentsTaskTest.cs
@@ -1,5 +1,6 @@
 using eppo_sdk.http;
 using eppo_sdk.tasks;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 
 namespace eppo_sdk_test.tasks;
@@ -19,10 +20,14 @@ public class FetchExperimentsTaskTest
             });
 
         // Use a shorter interval for faster testing
-        var task = new FetchExperimentsTask(mockConfig.Object, 200, 10);
+        var fakeTimeProvider = new FakeTimeProvider();
+        var task = new FetchExperimentsTask(mockConfig.Object, 200, 10, fakeTimeProvider);
 
-        // Wait for 2.5 intervals to ensure we get at least 2 calls (initial + 1 interval)
-        Thread.Sleep(500);
+        // Advance time to trigger the first timer callback (200ms)
+        fakeTimeProvider.Advance(TimeSpan.FromMilliseconds(200));
+        
+        // Advance time to trigger the second timer callback (accounting for 2.5x original interval)
+        fakeTimeProvider.Advance(TimeSpan.FromMilliseconds(300));
 
         // Verify at least 2 calls (initial call + at least one timer call)
         Assert.That(count, Is.GreaterThanOrEqualTo(2));


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Use `Microsoft.Extensions.TimeProvider.Testing` tools instead of `Thread.Sleep` for faster and more deterministic tests.

## Description
[//]: # (Describe your changes in detail)

## How has this been documented?
[//]: # (Please describe how you documented the developer impact of your changes; link to PRs or issues or explain why no documentation changes are required)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

